### PR TITLE
Migrate the oasis-core ledger integration to this repository

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -21,6 +21,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          # Check out pull request's HEAD commit instead of the merge commit to
+          # work-around an issue where wrong a commit is being checked out.
+          # For more details, see:
+          # https://github.com/actions/checkout/issues/299.
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Go 1.14
         uses: actions/setup-go@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 ledger-signer/ledger-signer.so
+oasis-core-ledger

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+ledger-signer/ledger-signer.so

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,3 +74,10 @@ linters-settings:
   maligned:
     # Print the suggested struct structure with a more effective memory layout.
     suggest-new: true
+
+run:
+  skip-dirs:
+    # golang-ci-lint requires that files compile for certain linters
+    # to run, and Go plugins do not compile unless `-buildmode=plugin`
+    # is set, which linters do not do.
+    - ledger-signer

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 include common.mk
 
 # Set all target as the default target.
-all: build-plugin
+all: build build-plugin
 
 # Build.
 build:
 	@$(ECHO) "$(MAGENTA)*** Building Go code...$(OFF)"
-	@$(GO) build -v ./...
+	@$(GO) build -v .
 
 # Build plugin.
 build-plugin:

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,17 @@
 include common.mk
 
 # Set all target as the default target.
-all: build
+all: build-plugin
 
 # Build.
 build:
 	@$(ECHO) "$(MAGENTA)*** Building Go code...$(OFF)"
 	@$(GO) build -v ./...
+
+# Build plugin.
+build-plugin:
+	@$(ECHO) "$(MAGENTA)*** Building ledger signer plugin code...$(OFF)"
+	@$(GO) build -trimpath -buildmode=plugin -v -o ./ledger-signer/ledger-signer.so ./ledger-signer
 
 # Format code.
 fmt:
@@ -49,10 +54,11 @@ test: $(test-targets)
 clean:
 	@$(ECHO) "$(CYAN)*** Cleaning up ...$(OFF)"
 	@$(GO) clean -x
+	@rm -f ./ledger-signer/ledger-signer.so
 
 # List of targets that are not actual files.
 .PHONY: \
-	all build \
+	all build build-plugin \
 	fmt \
 	$(lint-targets) lint \
 	$(test-targets) test \

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/oasisprotocol/oasis-core-ledger/internal"
+)
+
+var listCmd = &cobra.Command{
+	Use:   "list_devices",
+	Short: "list available devices by address",
+	Run:   doList,
+}
+
+func doList(cmd *cobra.Command, args []string) {
+	internal.ListOasisDevices(internal.ListingDerivationPath)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,56 @@
+// Package cmd implements the oasis-core-ledger tool.
+package cmd
+
+import (
+	// "fmt"
+
+	"github.com/spf13/cobra"
+	// flag "github.com/spf13/pflag"
+	// "github.com/spf13/viper"
+	// "github.com/oasisprotocol/oasis-core/go/common/logging"
+	// "github.com/oasisprotocol/oasis-core/go/oasis-node/cmd/common"
+)
+
+// const cfgLogLevel = "log.level"
+
+var rootCmd = &cobra.Command{
+	Use:     "oasis-core-ledger",
+	Short:   "Oasis Ledger Tool",
+	Version: "0.0.1",
+}
+
+// rootFlags = flag.NewFlagSet("", flag.ContinueOnError)
+
+// RootCommand returns the root (top level) cobra.Command.
+func RootCommand() *cobra.Command {
+	return rootCmd
+}
+
+// Execute spawns the main entry point after handling the command line arguments.
+func Execute() {
+	// Blah, The fact that oasis-core imports the ledger library causes
+	// issues, re-enable logging once the ledger support has been purged.
+	/*
+		var logLevel logging.Level
+		if err := logLevel.Set(viper.GetString(cfgLogLevel)); err != nil {
+			common.EarlyLogAndExit(fmt.Errorf("root: failed to set log level: %w", err))
+		}
+
+		if err := rootCmd.Execute(); err != nil {
+			common.EarlyLogAndExit(err)
+		}
+	*/
+	_ = rootCmd.Execute()
+}
+
+func init() { // nolint: gochecknoinits
+	/*
+		logLevel := logging.LevelInfo
+		rootFlags.Var(&logLevel, cfgLogLevel, "log level")
+		_ = viper.BindPFlags(rootFlags)
+		rootCmd.PersistentFlags().AddFlagSet(rootFlags)
+	*/
+
+	// Register all of the sub-commands.
+	rootCmd.AddCommand(listCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,15 @@ module github.com/oasisprotocol/oasis-core-ledger
 
 go 1.14
 
+// Updates the version used in spf13/cobra (dependency via tendermint) as
+// there is no release yet with the fix. Remove once an updated release of
+// spf13/cobra exists and tendermint is updated to include it.
+// https://github.com/spf13/cobra/issues/1091
+replace github.com/gorilla/websocket => github.com/gorilla/websocket v1.4.2
+
 require (
 	github.com/oasisprotocol/oasis-core/go v0.0.0-20200623153002-9e61aea5195b
+	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.6.1
 	github.com/zondax/ledger-go v0.12.1
 )

--- a/go.sum
+++ b/go.sum
@@ -235,9 +235,6 @@ github.com/gopherjs/gopherjs v0.0.0-20190910122728-9d188e94fb99/go.mod h1:wJfORR
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
-github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
@@ -279,6 +276,7 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/huin/goupnp v1.0.0/go.mod h1:n9v9KO1tAxYH82qOn+UTIFQDmx5n1Zxd/ClZDMX7Bnc=
 github.com/huin/goutil v0.0.0-20170803182201-1ca381bf3150/go.mod h1:PpLOETDnJ0o3iZrZfqZzyLl6l7F3c6L1oWn7OICBi6o=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
@@ -709,6 +707,7 @@ github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
+github.com/spf13/cobra v1.0.0 h1:6m/oheQuQ13N9ks4hubMG6BnvwOeaJrqSPLahSnczz8=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/internal/app.go
+++ b/internal/app.go
@@ -10,18 +10,35 @@ import (
 )
 
 const (
-	CLAConsumer  = 0x05
-	CLAValidator = 0xF5
+	// PathPurposeConsensus is set to 43, matching ledger's Validator app
+	PathPurposeConsensus uint32 = 43
 
-	INSGetVersion     = 0
-	INSGetAddrEd25519 = 1
-	INSSignEd25519    = 2
+	errMsgInvalidParameters = "[APDU_CODE_BAD_KEY_HANDLE] The parameters in the data field are incorrect"
+	errMsgInvalidated       = "[APDU_CODE_DATA_INVALID] Referenced data reversibly blocked (invalidated)"
+	errMsgRejected          = "[APDU_CODE_COMMAND_NOT_ALLOWED] Sign request rejected"
+
+	userMessageChunkSize = 250
+
+	claConsumer  = 0x05
+	claValidator = 0xF5
+
+	insGetVersion     = 0
+	insGetAddrEd25519 = 1
+	insSignEd25519    = 2
+
+	payloadChunkInit = 0
+	payloadChunkAdd  = 1
+	payloadChunkLast = 2
 )
 
-const (
-	PayloadChunkInit = 0
-	PayloadChunkAdd  = 1
-	PayloadChunkLast = 2
+var (
+	// ErrSignRequestRejected is the error returned when the user
+	// explicitly rejects a signature request.
+	ErrSignRequestRejected = fmt.Errorf("ledger/oasis: transaction rejected on Ledger device")
+
+	logger = logging.GetLogger("oasis/ledger")
+
+	minimumRequiredVersion = VersionInfo{0, 0, 3, 0}
 )
 
 type LedgerAppMode int
@@ -32,28 +49,33 @@ const (
 	UnknownMode
 )
 
-const (
-	// PathPurposeConsensus is set to 43, matching ledger's Validator app
-	PathPurposeConsensus uint32 = 43
-)
-
 // LedgerOasis represents a connection to the Ledger app.
 type LedgerOasis struct {
 	device  ledger_go.LedgerDevice
 	version VersionInfo
 }
 
-var logger = logging.GetLogger(LogModuleName)
-
-// SetLoggerModule sets logging module.
-func (ledger *LedgerOasis) SetLoggerModule(module string) {
-	logger = logging.GetLogger(module)
+func newLedgerOasis(device ledger_go.LedgerDevice, mode LedgerAppMode) *LedgerOasis {
+	return &LedgerOasis{
+		device: device,
+		version: VersionInfo{
+			AppMode: uint8(mode),
+		},
+	}
 }
 
-// GetModeForRole returns the app mode compatible with role.
-func GetModeForRole(role signature.SignerRole) LedgerAppMode {
+func getModeForRole(role signature.SignerRole) LedgerAppMode { // nolint: deadcode,unused
 	switch role {
 	case signature.SignerConsensus:
+		return ValidatorMode
+	default:
+		return ConsumerMode
+	}
+}
+
+func getModeForPath(path []uint32) LedgerAppMode {
+	switch path[0] {
+	case PathPurposeConsensus:
 		return ValidatorMode
 	default:
 		return ConsumerMode
@@ -64,6 +86,8 @@ func GetModeForRole(role signature.SignerRole) LedgerAppMode {
 func ListOasisDevices(path []uint32) {
 	ledgerAdmin := ledger_go.NewLedgerAdmin()
 
+	mode := getModeForPath(path)
+
 	for i := 0; i < ledgerAdmin.CountDevices(); i++ {
 		ledgerDevice, err := ledgerAdmin.Connect(i)
 		if err != nil {
@@ -71,7 +95,7 @@ func ListOasisDevices(path []uint32) {
 		}
 		defer ledgerDevice.Close()
 
-		app := LedgerOasis{ledgerDevice, VersionInfo{}}
+		app := newLedgerOasis(ledgerDevice, mode)
 		defer app.Close()
 
 		appVersion, err := app.GetVersion()
@@ -90,20 +114,11 @@ func ListOasisDevices(path []uint32) {
 	}
 }
 
-func GetModeForPath(path []uint32) LedgerAppMode {
-	switch path[0] {
-	case PathPurposeConsensus:
-		return ValidatorMode
-	default:
-		return ConsumerMode
-	}
-}
-
 // ConnectLedgerOasisApp connects to Oasis app based on address.
 func ConnectLedgerOasisApp(seekingAddress string, path []uint32) (*LedgerOasis, error) {
 	ledgerAdmin := ledger_go.NewLedgerAdmin()
 
-	mode := GetModeForPath(path)
+	mode := getModeForPath(path)
 
 	for i := 0; i < ledgerAdmin.CountDevices(); i++ {
 		ledgerDevice, err := ledgerAdmin.Connect(i)
@@ -111,7 +126,7 @@ func ConnectLedgerOasisApp(seekingAddress string, path []uint32) (*LedgerOasis, 
 			continue
 		}
 
-		app := LedgerOasis{ledgerDevice, VersionInfo{uint8(mode), 0, 0, 0}}
+		app := newLedgerOasis(ledgerDevice, mode)
 
 		_, address, err := app.GetAddressPubKeyEd25519(path)
 		if err != nil {
@@ -119,10 +134,10 @@ func ConnectLedgerOasisApp(seekingAddress string, path []uint32) (*LedgerOasis, 
 			continue
 		}
 		if seekingAddress == "" || address == seekingAddress {
-			return &app, nil
+			return app, nil
 		}
 	}
-	return nil, fmt.Errorf("no Oasis app with specified address found")
+	return nil, fmt.Errorf("ledger/oasis: no app with specified address found")
 }
 
 // FindLedgerOasisApp finds the Oasis app running in a Ledger device.
@@ -135,7 +150,7 @@ func FindLedgerOasisApp() (*LedgerOasis, error) {
 			continue
 		}
 
-		app := LedgerOasis{ledgerDevice, VersionInfo{}}
+		app := newLedgerOasis(ledgerDevice, LedgerAppMode(0))
 
 		appVersion, err := app.GetVersion()
 		if err != nil {
@@ -143,16 +158,15 @@ func FindLedgerOasisApp() (*LedgerOasis, error) {
 			continue
 		}
 
-		err = app.CheckVersion(*appVersion)
-		if err != nil {
+		if err = app.CheckVersion(*appVersion); err != nil {
 			app.Close()
 			continue
 		}
 
-		return &app, err
+		return app, nil
 	}
 
-	return nil, fmt.Errorf("no Oasis app found")
+	return nil, fmt.Errorf("ledger/oasis: no app found")
 }
 
 // Close closes a connection with the Oasis user app.
@@ -160,39 +174,31 @@ func (ledger *LedgerOasis) Close() error {
 	return ledger.device.Close()
 }
 
-// VersionIsSupported returns true if the App version is supported by this library.
+// CheckVersion returns nil if the App version is supported by this library.
 func (ledger *LedgerOasis) CheckVersion(ver VersionInfo) error {
-	return CheckVersion(ver, VersionInfo{0, 0, 3, 0})
-}
-
-// getCLA returns the CLA value for the current app mode.
-func (ledger *LedgerOasis) getCLA() byte {
-	switch LedgerAppMode(ledger.version.AppMode) {
-	case ValidatorMode:
-		return CLAValidator
-	default:
-		return CLAConsumer
-	}
+	return checkVersion(ver, minimumRequiredVersion)
 }
 
 // GetVersion returns the current version of the Oasis user app.
 func (ledger *LedgerOasis) GetVersion() (*VersionInfo, error) {
-	message := []byte{ledger.getCLA(), INSGetVersion, 0, 0, 0}
+	message := []byte{ledger.getCLA(), insGetVersion, 0, 0, 0}
 	response, err := ledger.device.Exchange(message)
 
-	logger.Debug("GetVersion requested:")
-	logger.Debug("message: " + hex.EncodeToString(message))
-	logger.Debug("response: " + hex.EncodeToString(response))
+	logger.Debug("GetVersion",
+		"err", err,
+		"message", hex.EncodeToString(message),
+		"response", hex.EncodeToString(response),
+	)
 
 	if err != nil {
-		logger.Error("error while getting version: %q", err)
-		return nil, err
+		return nil, fmt.Errorf("ledger/oasis: failed GetVersion request: %w", err)
 	}
 
 	if len(response) < 4 {
-		return nil, fmt.Errorf("invalid response")
+		return nil, fmt.Errorf("ledger/oasis: truncated GetVersion response")
 	}
 
+	// WTF this tramples over the AppMode used to connect to the device.
 	ledger.version = VersionInfo{
 		AppMode: response[0],
 		Major:   response[1],
@@ -233,74 +239,64 @@ func (ledger *LedgerOasis) ShowAddressPubKeyEd25519(bip44Path []uint32) (pubkey 
 	return ledger.retrieveAddressPubKeyEd25519(bip44Path, true)
 }
 
-func (ledger *LedgerOasis) GetBip44bytes(bip44Path []uint32, hardenCount int) ([]byte, error) {
-	pathBytes, err := GetBip44bytes(bip44Path, hardenCount)
-	if err != nil {
-		return nil, err
+func (ledger *LedgerOasis) getCLA() byte {
+	switch LedgerAppMode(ledger.version.AppMode) {
+	case ValidatorMode:
+		return claValidator
+	default:
+		return claConsumer
 	}
-
-	return pathBytes, nil
 }
 
 func (ledger *LedgerOasis) sign(bip44Path []uint32, context, transaction []byte) ([]byte, error) {
-	pathBytes, err := ledger.GetBip44bytes(bip44Path, 5)
+	pathBytes, err := getBip44bytes(bip44Path, 5)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("ledger/oasis: failed to get BIP44 bytes: %w", err)
 	}
 
 	chunks, err := prepareChunks(pathBytes, context, transaction, userMessageChunkSize)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("ledger/oasis: failed to prepare chunks: %w", err)
 	}
 
 	var finalResponse []byte
-
-	var message []byte
-
-	var chunkIndex int = 0
-
-	for chunkIndex < len(chunks) {
-		payloadLen := byte(len(chunks[chunkIndex]))
+	for idx, chunk := range chunks {
+		payloadLen := byte(len(chunk))
 
 		var payloadDesc byte
-		switch chunkIndex {
+		switch idx {
 		case 0:
-			payloadDesc = PayloadChunkInit
+			payloadDesc = payloadChunkInit
 		case len(chunks) - 1:
-			payloadDesc = PayloadChunkLast
+			payloadDesc = payloadChunkLast
 		default:
-			payloadDesc = PayloadChunkAdd
+			payloadDesc = payloadChunkAdd
 		}
 
-		message = []byte{ledger.getCLA(), INSSignEd25519, payloadDesc, 0, payloadLen}
-		message = append(message, chunks[chunkIndex]...)
+		message := []byte{ledger.getCLA(), insSignEd25519, payloadDesc, 0, payloadLen}
+		message = append(message, chunk...)
 
 		response, err := ledger.device.Exchange(message)
 
-		logger.Debug("Sign requested:")
-		logger.Debug("message: " + hex.EncodeToString(message))
-		logger.Debug("response: " + hex.EncodeToString(response))
+		logger.Debug("Sign",
+			"err", err,
+			"message", hex.EncodeToString(message),
+			"response", hex.EncodeToString(response),
+		)
 
 		if err != nil {
-			if err.Error() == "[APDU_CODE_BAD_KEY_HANDLE] The parameters in the data field are incorrect" {
-				// In this special case, we can extract additional info
-				errorMsg := string(response)
-				return nil, fmt.Errorf(errorMsg)
+			switch err.Error() {
+			case errMsgInvalidParameters, errMsgInvalidated:
+				return nil, fmt.Errorf("ledger/oasis: failed to sign: %s", string(response))
+			case errMsgRejected:
+				return nil, ErrSignRequestRejected
 			}
-			if err.Error() == "[APDU_CODE_DATA_INVALID] Referenced data reversibly blocked (invalidated)" {
-				errorMsg := string(response)
-				return nil, fmt.Errorf(errorMsg)
-			}
-			if err.Error() == "[APDU_CODE_COMMAND_NOT_ALLOWED] Sign request rejected" {
-				errorMsg := string(response)
-				return nil, fmt.Errorf(errorMsg)
-			}
-			return nil, err
+			return nil, fmt.Errorf("ledger/oasis: failed to sign: %w", err)
 		}
 
 		finalResponse = response
-		chunkIndex++
 	}
+
 	return finalResponse, nil
 }
 
@@ -309,9 +305,9 @@ func (ledger *LedgerOasis) retrieveAddressPubKeyEd25519(
 	bip44Path []uint32,
 	requireConfirmation bool,
 ) (pubkey []byte, addr string, err error) {
-	pathBytes, err := ledger.GetBip44bytes(bip44Path, 5)
+	pathBytes, err := getBip44bytes(bip44Path, 5)
 	if err != nil {
-		return nil, "", err
+		return nil, "", fmt.Errorf("ledger/oasis: failed to get BIP44 bytes: %w", err)
 	}
 
 	p1 := byte(0)
@@ -320,25 +316,27 @@ func (ledger *LedgerOasis) retrieveAddressPubKeyEd25519(
 	}
 
 	// Prepare message
-	header := []byte{ledger.getCLA(), INSGetAddrEd25519, p1, 0, 0}
+	header := []byte{ledger.getCLA(), insGetAddrEd25519, p1, 0, 0}
 	message := append(header, pathBytes...)
 	message[4] = byte(len(message) - len(header)) // update length
 
 	response, err := ledger.device.Exchange(message)
 
-	logger.Debug("PubKey requested:")
-	logger.Debug("message: " + hex.EncodeToString(message))
-	logger.Debug("response: " + hex.EncodeToString(response))
+	logger.Debug("GetAddrEd25519",
+		"err", err,
+		"message", hex.EncodeToString(message),
+		"response", hex.EncodeToString(response),
+	)
 
 	if err != nil {
-		return nil, "", err
+		return nil, "", fmt.Errorf("ledger/oasis: failed to request public key: %w", err)
 	}
 	if len(response) < 39 {
-		return nil, "", fmt.Errorf("invalid response")
+		return nil, "", fmt.Errorf("ledger/oasis: truncated GetAddrEd25519 response")
 	}
 
 	pubkey = response[0:32]
 	addr = string(response[32:])
 
-	return pubkey, addr, err
+	return pubkey, addr, nil
 }

--- a/internal/app.go
+++ b/internal/app.go
@@ -10,8 +10,26 @@ import (
 )
 
 const (
-	// PathPurposeConsensus is set to 43, matching ledger's Validator app
+	// PathPurposeBIP44 is set to 44 to indicate the use of the BIP-0044's hierarchy:
+	// https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki.
+	PathPurposeBIP44 uint32 = 44
+	// PathPurposeConsensus is set to 43, matching ledger's Validator
+	// app.  This uses the (proposed) BIP-0043 extension that specifies
+	// the purpose of non-Bitcoin uses:
+	// https://github.com/bitcoin/bips/pull/523/files
 	PathPurposeConsensus uint32 = 43
+	// PathSubPurposeConsensus is set to 0 to indicate it is to be used for
+	// consensus-related things.
+	PathSubPurposeConsensus uint32 = 0
+
+	// ListingPathCoinType is set to 474, the index registered to Oasis in the SLIP-0044 registry.
+	ListingPathCoinType uint32 = 474
+	// ListingPathAccount is the account index used to list and connect to Ledger devices by address.
+	ListingPathAccount uint32 = 0
+	// ListingPathChange indicates an external chain.
+	ListingPathChange uint32 = 0
+	// ListingPathIndex is the address index used to list and connect to Ledger devices by address.
+	ListingPathIndex uint32 = 0
 
 	errMsgInvalidParameters = "[APDU_CODE_BAD_KEY_HANDLE] The parameters in the data field are incorrect"
 	errMsgInvalidated       = "[APDU_CODE_DATA_INVALID] Referenced data reversibly blocked (invalidated)"
@@ -32,6 +50,11 @@ const (
 )
 
 var (
+	// ListingDerivationPath is the path used to list and connect to devices by address.
+	ListingDerivationPath = []uint32{
+		PathPurposeBIP44, ListingPathCoinType, ListingPathAccount, ListingPathChange, ListingPathIndex,
+	}
+
 	// ErrSignRequestRejected is the error returned when the user
 	// explicitly rejects a signature request.
 	ErrSignRequestRejected = fmt.Errorf("ledger/oasis: transaction rejected on Ledger device")

--- a/internal/common_test.go
+++ b/internal/common_test.go
@@ -2,12 +2,11 @@ package internal
 
 import (
 	"encoding/base64"
-	"encoding/hex"
 	"fmt"
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var coinContext = "oasis-core/consensus: tx for chain 7b02d647e8997bacebce96723f6904029ec78b67c261c4bdddb5e47de1ab31fa"
@@ -15,167 +14,162 @@ var coinContext = "oasis-core/consensus: tx for chain 7b02d647e8997bacebce96723f
 func getDummyTx() []byte {
 	base64tx := "pGNmZWWiY2dhcxkD6GZhbW91bnRCB9BkYm9keaJneGZlcl90b1UA4ywoibwEEhHt7fqvlNL9hmmLsH9reGZlcl90b2tlbnNFJ5TKJABlbm9uY2UHZm1ldGhvZHBzdGFraW5nLlRyYW5zZmVy" //nolint: lll
 	tx, _ := base64.StdEncoding.DecodeString(base64tx)
-	println(hex.EncodeToString(tx))
 	return tx
 }
 
 func Test_PrintVersion(t *testing.T) {
+	require := require.New(t)
+
 	reqVersion := VersionInfo{0, 1, 2, 3}
 	s := fmt.Sprintf("%v", reqVersion)
-	assert.Equal(t, "1.2.3", s)
+	require.Equal("1.2.3", s)
 }
 
-func Test_PathGeneration0(t *testing.T) {
-	bip44Path := []uint32{44, 100, 0, 0, 0}
+func TestPathGeneration(t *testing.T) {
+	const expectedLength = 20
 
-	pathBytes, err := GetBip44bytes(bip44Path, 0)
-	if err != nil {
-		t.Fatalf("Detected error, err: %s\n", err.Error())
+	type pathGenerationTest struct {
+		name        string
+		path        []uint32
+		hardenCount int
+		expected    string
 	}
 
-	fmt.Printf("Path: %x\n", pathBytes)
+	for _, testCase := range []pathGenerationTest{
+		{
+			name:        "TC0",
+			path:        []uint32{44, 100, 0, 0, 0},
+			hardenCount: 0,
+			expected:    "2c00000064000000000000000000000000000000",
+		},
+		{
+			name:        "TC2",
+			path:        []uint32{44, 123, 0, 0, 0},
+			hardenCount: 2,
+			expected:    "2c0000807b000080000000000000000000000000",
+		},
+		{
+			name:        "TC3",
+			path:        []uint32{44, 123, 0, 0, 0},
+			hardenCount: 3,
+			expected:    "2c0000807b000080000000800000000000000000",
+		},
+	} {
+		tc := testCase // Shut up scopelint.
+		t.Run(testCase.name, func(tt *testing.T) {
+			require := require.New(tt)
 
-	assert.Equal(
-		t,
-		20,
-		len(pathBytes),
-		"PathBytes has wrong length: %x, expected length: %x\n", pathBytes, 40)
+			pathBytes, err := getBip44bytes(tc.path, tc.hardenCount)
+			require.NoError(err, "GetBip44bytes")
 
-	assert.Equal(
-		t,
-		"2c00000064000000000000000000000000000000",
-		fmt.Sprintf("%x", pathBytes),
-		"Unexpected PathBytes\n")
+			tt.Logf("Path: %x", pathBytes)
+
+			require.Len(pathBytes, expectedLength, "pathBytes has the correct length")
+			require.Equal(tc.expected, fmt.Sprintf("%x", pathBytes), "Generated path is correct")
+		})
+	}
 }
 
-func Test_PathGeneration2(t *testing.T) {
-	bip44Path := []uint32{44, 123, 0, 0, 0}
+func validateChunks(
+	t *testing.T,
+	require *require.Assertions,
+	pathBytes, context, message []byte,
+	chunks [][]byte,
+	chunkSize int,
+) {
+	expected := append(pathBytes, byte(len(context)))
+	expected = append(expected, context...)
+	expected = append(expected, message...)
 
-	pathBytes, err := GetBip44bytes(bip44Path, 2)
-	if err != nil {
-		t.Fatalf("Detected error, err: %s\n", err.Error())
+	nrChunks := len(chunks)
+
+	reassembled := make([]byte, 0, len(expected))
+	for i, v := range chunks {
+		if i == 0 {
+			require.Equal(pathBytes, v, "First chunk should be pathBytes")
+		} else {
+			if i < nrChunks-1 {
+				require.Len(v, chunkSize, "Non-final/non-path chunks should be fully packed")
+			} else {
+				require.NotZero(len(v), "Final chunk should have non-zero length")
+				require.LessOrEqualf(len(v), chunkSize, "Chunk[%d]: invalid length")
+			}
+		}
+
+		reassembled = append(reassembled, v...)
+
+		t.Logf("Chunk[%d]: %x", i, v)
 	}
 
-	fmt.Printf("Path: %x\n", pathBytes)
-
-	assert.Equal(
-		t,
-		20,
-		len(pathBytes),
-		"PathBytes has wrong length: %x, expected length: %x\n", pathBytes, 40)
-
-	assert.Equal(
-		t,
-		"2c0000807b000080000000000000000000000000",
-		fmt.Sprintf("%x", pathBytes),
-		"Unexpected PathBytes\n")
-}
-
-func Test_PathGeneration3(t *testing.T) {
-	bip44Path := []uint32{44, 123, 0, 0, 0}
-
-	pathBytes, err := GetBip44bytes(bip44Path, 3)
-	if err != nil {
-		t.Fatalf("Detected error, err: %s\n", err.Error())
-	}
-
-	fmt.Printf("Path: %x\n", pathBytes)
-
-	assert.Equal(
-		t,
-		20,
-		len(pathBytes),
-		"PathBytes has wrong length: %x, expected length: %x\n", pathBytes, 40)
-
-	assert.Equal(
-		t,
-		"2c0000807b000080000000800000000000000000",
-		fmt.Sprintf("%x", pathBytes),
-		"Unexpected PathBytes\n")
+	require.Equal(expected, reassembled, "Reconstructed message should match")
 }
 
 func Test_ChunkGeneration(t *testing.T) {
+	require := require.New(t)
+
 	bip44Path := []uint32{44, 123, 0, 0, 0}
+	pathBytes, err := getBip44bytes(bip44Path, 0)
+	require.NoError(err, "GetBip44bytes")
 
-	pathBytes, err := GetBip44bytes(bip44Path, 0)
-	if err != nil {
-		t.Fatalf("Detected error, err: %s\n", err.Error())
-	}
-
+	context := []byte(coinContext)
 	message := getDummyTx()
 
-	chunks, _ := prepareChunks(pathBytes, []byte(coinContext), message, userMessageChunkSize)
+	chunks, err := prepareChunks(pathBytes, context, message, userMessageChunkSize)
+	require.NoError(err, "prepareChunks")
 
-	assert.Equal(
-		t,
-		chunks[0],
-		pathBytes,
-		"First chunk should be pathBytes\n")
+	validateChunks(t, require, pathBytes, context, message, chunks, userMessageChunkSize)
 }
 
 func Test_ChunkGeneration2(t *testing.T) {
-	bip44Path := []uint32{44, 123, 0, 0, 0}
+	require := require.New(t)
 
-	pathBytes, err := GetBip44bytes(bip44Path, 0)
-	if err != nil {
-		t.Fatalf("Detected error, err: %s\n", err.Error())
-	}
+	bip44Path := []uint32{44, 123, 0, 0, 0}
+	pathBytes, err := getBip44bytes(bip44Path, 0)
+	require.NoError(err, "GetBip44bytes")
 
 	context := []byte{0xa1, 0xa2, 0xa3, 0xa4}
 	message := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}
 
-	println(hex.EncodeToString(context))
-	println(hex.EncodeToString(message))
+	t.Logf("Context: %x", context)
+	t.Logf("Message: %x", message)
 
-	chunks, _ := prepareChunks(pathBytes, context, message, 4)
+	const chunkSize = 4
+	chunks, err := prepareChunks(pathBytes, context, message, chunkSize)
+	require.NoError(err, "prepareChunks")
 
-	for index, c := range chunks {
-		println(index, hex.EncodeToString(c))
-	}
-
-	assert.Equal(
-		t,
-		5,
-		len(chunks),
-		"incorrect number of chunks\n")
+	validateChunks(t, require, pathBytes, context, message, chunks, chunkSize)
+	require.Len(chunks, 5, "incorrect number of chunks")
 }
 
 func Test_ChunkGeneration_invalidContextLength(t *testing.T) {
-	bip44Path := []uint32{44, 123, 0, 0, 0}
+	require := require.New(t)
 
-	pathBytes, err := GetBip44bytes(bip44Path, 0)
-	if err != nil {
-		t.Fatalf("Detected error, err: %s\n", err.Error())
-	}
+	bip44Path := []uint32{44, 123, 0, 0, 0}
+	pathBytes, err := getBip44bytes(bip44Path, 0)
+	require.NoError(err, "GetBip44bytes")
 
 	message := getDummyTx()
+	context := []byte(strings.Repeat("A", 256))
 
-	coinContext := strings.Repeat("A", 256)
+	_, err = prepareChunks(pathBytes, context, message, userMessageChunkSize)
+	require.Error(err, "oversized context should fail")
 
-	_, errChunk := prepareChunks(pathBytes, []byte(coinContext), message, userMessageChunkSize)
-
-	fmt.Printf("Error: %s\n", errChunk)
-
-	assert.Error(t, errChunk)
+	t.Logf("Error: %v", err)
 }
 
 func Test_ChunkGeneration_contextLengthIsZero(t *testing.T) {
-	bip44Path := []uint32{44, 123, 0, 0, 0}
+	require := require.New(t)
 
-	pathBytes, err := GetBip44bytes(bip44Path, 0)
-	if err != nil {
-		t.Fatalf("Detected error, err: %s\n", err.Error())
-	}
+	bip44Path := []uint32{44, 123, 0, 0, 0}
+	pathBytes, err := getBip44bytes(bip44Path, 0)
+	require.NoError(err, "GetBip44bytes")
 
 	message := getDummyTx()
+	context := []byte{}
 
-	coinContext := ""
+	chunks, err := prepareChunks(pathBytes, context, message, userMessageChunkSize)
+	require.NoError(err, "prepareChunks")
 
-	chunks, _ := prepareChunks(pathBytes, []byte(coinContext), message, userMessageChunkSize)
-
-	assert.Equal(
-		t,
-		byte(0),
-		chunks[1][0],
-		"First byte should be 0 because context is empty\n")
+	validateChunks(t, require, pathBytes, context, message, chunks, userMessageChunkSize)
+	require.Zero(chunks[1][0], "First non-path byte should be 0 because context is empty")
 }

--- a/ledger-signer/ledger_signer.go
+++ b/ledger-signer/ledger_signer.go
@@ -1,0 +1,206 @@
+// Package main implements the ledger backed oasis-node signer plugin.
+package main
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+
+	"github.com/oasisprotocol/oasis-core-ledger/internal"
+)
+
+var (
+	_ signature.SignerFactoryCtor = newPluginFactory
+	_ signature.SignerFactory     = (*ledgerFactory)(nil)
+	_ signature.Signer            = (*ledgerSigner)(nil)
+
+	// signerPathCoinType is set to 474, the number associated with Oasis ROSE.
+	signerPathCoinType uint32 = 474
+	// signerPathAccount is the account index used to sign transactions.
+	signerPathAccount uint32 = 0
+	// SignerPathChange indicates an external chain.
+	signerPathChange uint32 = 0
+
+	// signerEntityDerivationRootPath is the BIP-0032 path prefix used for generating
+	// an Entity signer.
+	signerEntityDerivationRootPath = []uint32{
+		internal.PathPurposeBIP44,
+		signerPathCoinType,
+		signerPathAccount,
+		signerPathChange,
+	}
+	// signerConsensusDerivationRootPath is the derivation path prefix used for
+	// generating a consensus signer.
+	signerConsensusDerivationRootPath = []uint32{
+		internal.PathPurposeConsensus,
+		signerPathCoinType,
+		internal.PathSubPurposeConsensus,
+		signerPathAccount,
+	}
+
+	roleDerivationRootPaths = map[signature.SignerRole][]uint32{
+		signature.SignerEntity:    signerEntityDerivationRootPath,
+		signature.SignerConsensus: signerConsensusDerivationRootPath,
+	}
+)
+
+// GetPluginCtor is the plugin's entry point.
+func GetPluginCtor() signature.SignerFactoryCtor {
+	return newPluginFactory
+}
+
+type factoryConfig struct {
+	address string
+	index   uint32
+}
+
+func newFactoryConfig(cfgStr string) (*factoryConfig, error) {
+	kvStrs := strings.Split(cfgStr, ";")
+
+	var (
+		cfg                      factoryConfig
+		foundAddress, foundIndex bool
+	)
+	for _, v := range kvStrs {
+		spl := strings.Split(v, "=")
+		if len(spl) != 2 {
+			return nil, fmt.Errorf("malformed k/v pair: '%s'", v)
+		}
+
+		key := strings.ToLower(spl[0])
+		switch key {
+		case "address":
+			if foundAddress {
+				return nil, fmt.Errorf("address already configured")
+			}
+			cfg.address = spl[1]
+			foundAddress = true
+		case "index":
+			if foundIndex {
+				return nil, fmt.Errorf("index already configured")
+			}
+			idx, err := strconv.ParseUint(spl[1], 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("malformed index: %w", err)
+			}
+			cfg.index = uint32(idx)
+			foundIndex = true
+		default:
+			return nil, fmt.Errorf("unknown configuration option: '%v'", spl[0])
+		}
+	}
+
+	if !foundAddress {
+		return nil, fmt.Errorf("address not configured")
+	}
+	if !foundIndex {
+		return nil, fmt.Errorf("index not configured")
+	}
+
+	return &cfg, nil
+}
+
+func newPluginFactory(config interface{}, roles ...signature.SignerRole) (signature.SignerFactory, error) {
+	cfgStr, ok := config.(string)
+	if !ok {
+		return nil, fmt.Errorf("ledger: invalid configuration type")
+	}
+	cfg, err := newFactoryConfig(cfgStr)
+	if err != nil {
+		return nil, fmt.Errorf("ledger: failed to parse configuration: %w", err)
+	}
+
+	return &ledgerFactory{
+		roles:   roles,
+		address: cfg.address,
+		index:   cfg.index,
+	}, nil
+}
+
+type ledgerFactory struct {
+	roles   []signature.SignerRole
+	address string
+	index   uint32
+}
+
+func (fac *ledgerFactory) EnsureRole(role signature.SignerRole) error {
+	for _, v := range fac.roles {
+		if v == role {
+			return nil
+		}
+	}
+	return signature.ErrRoleMismatch
+}
+
+func (fac *ledgerFactory) Generate(role signature.SignerRole, _rng io.Reader) (signature.Signer, error) {
+	// Generate has the same functionality as Load, since all keys are
+	// generated on the Ledger device.
+	return fac.Load(role)
+}
+
+func (fac *ledgerFactory) Load(role signature.SignerRole) (signature.Signer, error) {
+	pathPrefix, ok := roleDerivationRootPaths[role]
+	if !ok {
+		return nil, fmt.Errorf("ledger: role %d is not supported when using the Ledger backed signer", role)
+	}
+	path := append(pathPrefix, fac.index)
+	device, err := internal.ConnectLedgerOasisApp(fac.address, path)
+	if err != nil {
+		return nil, fmt.Errorf("ledger: failed to connect to device: %w", err)
+	}
+
+	return &ledgerSigner{device, path, nil}, nil
+}
+
+type ledgerSigner struct {
+	device    *internal.LedgerOasis
+	path      []uint32
+	publicKey *signature.PublicKey
+}
+
+func (s *ledgerSigner) Public() signature.PublicKey {
+	if s.publicKey != nil {
+		return *s.publicKey
+	}
+
+	var pubKey signature.PublicKey
+	retrieved, err := s.device.GetPublicKeyEd25519(s.path)
+	if err != nil {
+		panic(fmt.Errorf("ledger: failed to retrieve public key from device: %w", err))
+	}
+	if err = pubKey.UnmarshalBinary(retrieved); err != nil {
+		panic(fmt.Errorf("ledger: device returned malfored public key: %w", err))
+	}
+	s.publicKey = &pubKey
+
+	return pubKey
+}
+
+// ContextSign generates a signature with the private key over the context and
+// message.
+func (s *ledgerSigner) ContextSign(context signature.Context, message []byte) ([]byte, error) {
+	preparedContext, err := signature.PrepareSignerContext(context)
+	if err != nil {
+		return nil, fmt.Errorf("ledger: failed to prepare signing context: %w", err)
+	}
+
+	signature, err := s.device.SignEd25519(s.path, preparedContext, message)
+	if err != nil {
+		return nil, fmt.Errorf("ledger: failed to sign message: %w", err)
+	}
+
+	return signature, nil
+}
+
+// String returns the address of the account on the Ledger device.
+func (s *ledgerSigner) String() string {
+	return fmt.Sprintf("[ledger signer: %s]", s.Public())
+}
+
+// Reset tears down the Signer.
+func (s *ledgerSigner) Reset() {
+	s.device.Close()
+}

--- a/ledger-signer/ledger_signer_test.go
+++ b/ledger-signer/ledger_signer_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFactoryConfig(t *testing.T) {
+	require := require.New(t)
+
+	expectedConfig := &factoryConfig{
+		address: "1640 Riverside Drive",
+		index:   17,
+	}
+
+	cfgStr := fmt.Sprintf("address=%s;index=%d", expectedConfig.address, expectedConfig.index)
+	cfg, err := newFactoryConfig(cfgStr)
+	require.NoError(err, "newFactoryConfig")
+	require.Equal(expectedConfig, cfg, "config should parse")
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,10 @@
+// Package main implements the oasis-core-ledger CLI tool.
+package main
+
+import (
+	"github.com/oasisprotocol/oasis-core-ledger/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
 * [x] Clean up the existing code under the internal package
 * [x] Migrate the signer into a go plugin
 * [x] Migrate the tool to enumerate devices to a command

Notes:
 * We set more than `-trimpath` when building `oasis-node`, I'm not sure if that will make the runtime library's plugin loader mad if we don't set the same options when building the plugin.
 * Someone that's not me will need to bump the oasis-core import to the exact version the plugin is supposed to be built against.