### PR TITLE
internal: Clean up the app tests

### DIFF
--- a/internal/app_test.go
+++ b/internal/app_test.go
@@ -1,228 +1,170 @@
-// +build ledgerhw
-
 package internal
 
 import (
 	"crypto/ed25519"
 	"crypto/sha512"
-	"encoding/hex"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// Ledger Test Mnemonic: equip will roof matter pink blind book anxiety banner elbow sun young
-
-func Test_FindLedger(t *testing.T) {
-	app, err := FindLedgerOasisApp()
-	if err != nil {
-		t.Fatalf(err.Error())
+func TestFindLedger(t *testing.T) {
+	if !testUsingHardware() {
+		t.Skipf("Hardware not configured for tests")
 	}
 
-	assert.NotNil(t, app)
+	require := require.New(t)
+
+	app, err := FindLedgerOasisApp()
+	require.NoError(err, "FindLedgerOasisApp")
+	require.NotNil(app, "Must find a ledger device and initialize the interface")
+
 	defer app.Close()
 }
 
-func Test_UserGetVersion(t *testing.T) {
-	app, err := FindLedgerOasisApp()
-	if err != nil {
-		t.Fatalf(err.Error())
-	}
+func TestUserGetVersion(t *testing.T) {
+	require, assert := require.New(t), assert.New(t)
+
+	app, err := testFindLedgerOasisApp()
+	require.NoError(err, "FindLedgerOasisApp")
 	defer app.Close()
 
 	version, err := app.GetVersion()
-	require.Nil(t, err, "Detected error")
-	fmt.Println(version)
+	require.NoError(err, "GetVersion")
 
-	assert.Equal(t, uint8(0x0), version.AppMode, "TESTING MODE ENABLED!!")
-	assert.Equal(t, uint8(0x0), version.Major, "Wrong Major version")
-	assert.Equal(t, uint8(0xd), version.Minor, "Wrong Minor version")
+	t.Logf("Version: %s", version)
+
+	assert.Equal(uint8(0x0), version.AppMode, "TESTING MODE ENABLED!!")
+	assert.Equal(uint8(0x0), version.Major, "Wrong Major version")
+	assert.Equal(uint8(0xd), version.Minor, "Wrong Minor version")
 }
 
-func Test_UserGetPublicKey(t *testing.T) {
-	app, err := FindLedgerOasisApp()
-	if err != nil {
-		t.Fatalf(err.Error())
-	}
+func TestUserGetPublicKey(t *testing.T) {
+	require := require.New(t)
+
+	app, err := testFindLedgerOasisApp()
+	require.NoError(err, "FindLedgerOasisApp")
 	defer app.Close()
 
 	path := []uint32{44, 474, 5, 0, 21}
 
 	pubKey, err := app.GetPublicKeyEd25519(path)
-	if err != nil {
-		t.Fatalf("Detected error, err: %s\n", err.Error())
-	}
+	require.NoError(err, "GetPublicKeyEd25519")
 
-	assert.Equal(t, 32, len(pubKey),
-		"Public key has wrong length: %x, expected length: %x\n", pubKey, 32)
-	fmt.Printf("PUBLIC KEY: %x\n", pubKey)
-
-	assert.Equal(t,
-		"d71c79ffd5a6d438de89c833e00222a2e80ed94e9929350ef7c1c97d1d13295d",
-		hex.EncodeToString(pubKey),
-		"Unexpected pubkey")
+	checkTestKey(t, pubKey, "", path)
 }
 
-func Test_GetAddressPubKeyEd25519_Zero(t *testing.T) {
-	app, err := FindLedgerOasisApp()
-	if err != nil {
-		t.Fatalf(err.Error())
-	}
+func TestGetAddressPubKeyEd25519_Zero(t *testing.T) {
+	require := require.New(t)
+
+	app, err := testFindLedgerOasisApp()
+	require.NoError(err, "FindLedgerOasisApp")
 	defer app.Close()
 
 	path := []uint32{44, 474, 0, 0, 0}
 
 	pubKey, addr, err := app.GetAddressPubKeyEd25519(path)
-	if err != nil {
-		t.Fatalf("Detected error, err: %s\n", err.Error())
-	}
+	require.NoError(err, "GetAddressPublicKeyEd25519")
 
-	fmt.Printf("PUBLIC KEY : %x\n", pubKey)
-	fmt.Printf("BECH32 ADDR: %s\n", addr)
-
-	assert.Equal(t, 32, len(pubKey), "Public key has wrong length: %x, expected length: %x\n", pubKey, 32)
-
-	assert.Equal(t, "97e72e6e83ec39eb98d7e9189513aba662a08a210b9974b0f7197458483c7161", hex.EncodeToString(pubKey), "Unexpected pubkey")
-	assert.Equal(t, "oasis1jlnjum5rasu7hxxhayvf2yat5e32pz3ppwvhfv8hr969sjpuw9sgn54g9", addr, "Unexpected addr")
+	checkTestKey(t, pubKey, addr, path)
 }
 
-func Test_GetAddressPubKeyEd25519(t *testing.T) {
-	app, err := FindLedgerOasisApp()
-	if err != nil {
-		t.Fatalf(err.Error())
-	}
+func TestGetAddressPubKeyEd25519(t *testing.T) {
+	require := require.New(t)
+
+	app, err := testFindLedgerOasisApp()
+	require.NoError(err, "FindLedgerOasisApp")
 	defer app.Close()
 
 	path := []uint32{44, 474, 5, 0, 21}
 
 	pubKey, addr, err := app.GetAddressPubKeyEd25519(path)
-	if err != nil {
-		t.Fatalf("Detected error, err: %s\n", err.Error())
-	}
+	require.NoError(err, "GetAddressPublicKeyEd25519")
 
-	fmt.Printf("PUBLIC KEY : %x\n", pubKey)
-	fmt.Printf("BECH32 ADDR: %s\n", addr)
-
-	assert.Equal(t, 32, len(pubKey), "Public key has wrong length: %x, expected length: %x\n", pubKey, 32)
-
-	assert.Equal(t, "d71c79ffd5a6d438de89c833e00222a2e80ed94e9929350ef7c1c97d1d13295d", hex.EncodeToString(pubKey), "Unexpected pubkey")
-	assert.Equal(t, "oasis16uw8nl745m2r3h5feqe7qq3z5t5qak2wny5n2rhhc8yh68gn99wwcq4ef", addr, "Unexpected addr")
+	checkTestKey(t, pubKey, addr, path)
 }
 
-func Test_ShowAddressPubKeyEd25519(t *testing.T) {
-	app, err := FindLedgerOasisApp()
-	if err != nil {
-		t.Fatalf(err.Error())
-	}
+func TestShowAddressPubKeyEd25519(t *testing.T) {
+	require := require.New(t)
+
+	app, err := testFindLedgerOasisApp()
+	require.NoError(err, "FindLedgerOasisApp")
 	defer app.Close()
 
 	path := []uint32{44, 474, 5, 0, 21}
 
 	pubKey, addr, err := app.ShowAddressPubKeyEd25519(path)
-	if err != nil {
-		t.Fatalf("Detected error, err: %s\n", err.Error())
-	}
+	require.NoError(err, "ShowAddressPublicKeyEd25519")
 
-	fmt.Printf("PUBLIC KEY : %x\n", pubKey)
-	fmt.Printf("BECH32 ADDR: %s\n", addr)
-
-	assert.Equal(t, 32, len(pubKey), "Public key has wrong length: %x, expected length: %x\n", pubKey, 32)
-
-	assert.Equal(t, "d71c79ffd5a6d438de89c833e00222a2e80ed94e9929350ef7c1c97d1d13295d", hex.EncodeToString(pubKey), "Unexpected pubkey")
-	assert.Equal(t, "oasis16uw8nl745m2r3h5feqe7qq3z5t5qak2wny5n2rhhc8yh68gn99wwcq4ef", addr, "Unexpected addr")
+	checkTestKey(t, pubKey, addr, path)
 }
 
-func Test_UserPK_HDPaths(t *testing.T) {
-	app, err := FindLedgerOasisApp()
-	if err != nil {
-		t.Fatalf(err.Error())
-	}
+func TestUserPKHDPaths(t *testing.T) {
+	require := require.New(t)
+
+	app, err := testFindLedgerOasisApp()
+	require.NoError(err, "FindLedgerOasisApp")
 	defer app.Close()
 
 	path := []uint32{44, 474, 0, 0, 0}
-
-	expected := []string{
-		"97e72e6e83ec39eb98d7e9189513aba662a08a210b9974b0f7197458483c7161",
-		"54e98ea8afcf1321eddd2c91ee71f7f9237c38bd8c3242057be5c7ce3f46abbd",
-		"7d10a11e1a4ef5adea33eb9f3332c6d221c12d461299de32d10e6cfffcd776d8",
-		"00f3a005092933e8c2956d7ece62cbd39718678e35bf2a7370c344e9e755bc18",
-		"3c713b1b2623c3a1c997b7b80c9dce4c49bf32c36dabb5cea6ce2cb6e89eb600",
-		"636586ccbca4c1a5035552faccbce3b6ca59e6181ce17a3d84bcf6d9c5d120d1",
-		"887fca7f936cad2733c6c8100c2ca8c612a37b9c7645b4a4b58445e5ceb6e862",
-		"e2c22521953488a0135a4348dfd7544ff8ecfa1744fda1bef2f935476b909115",
-		"5fec8d7031821c0a7ebbc18bdcaad826e1cf83323e172ce0a4f36a8e04792696",
-		"72fde11509927324be809cdc815b258678ea74b2aa1d5e5490a960acd86c7a7e",
-	}
 
 	for i := uint32(0); i < 10; i++ {
 		path[4] = i
 
 		pubKey, err := app.GetPublicKeyEd25519(path)
-		if err != nil {
-			t.Fatalf("Detected error, err: %s\n", err.Error())
-		}
+		require.NoError(err, "GetPublicKeyEd25519")
 
-		assert.Equal(
-			t,
-			32,
-			len(pubKey),
-			"Public key has wrong length: %x, expected length: %x\n", pubKey, 32)
-
-		assert.Equal(
-			t,
-			expected[i],
-			hex.EncodeToString(pubKey),
-			"Public key 44'/474'/0'/0/%d does not match\n", i)
+		checkTestKey(t, pubKey, "", path)
 	}
 }
 
-func Test_Sign(t *testing.T) {
-	app, err := FindLedgerOasisApp()
-	if err != nil {
-		t.Fatalf(err.Error())
+func TestSign(t *testing.T) {
+	if !testUsingHardware() {
+		// Can't sign with expected public key due to the incomplete
+		// mock implementation.
+		t.Skipf("Hardware not configured for tests")
 	}
+
+	require := require.New(t)
+
+	app, err := testFindLedgerOasisApp()
+	require.NoError(err, "FindLedgerOasisApp")
 	defer app.Close()
 
 	path := []uint32{44, 474, 0, 0, 5}
 
 	message := getDummyTx()
+	context := []byte(coinContext)
 
-	println(coinContext)
-	println(hex.EncodeToString(message))
+	t.Logf("Context: %x", context)
+	t.Logf("Message: %x", message)
 
-	signature, err := app.SignEd25519(path, []byte(coinContext), message)
-	if err != nil {
-		t.Fatalf("[Sign] Error: %s\n", err.Error())
-	}
+	signature, err := app.SignEd25519(path, context, message)
+	require.NoError(err, "SignEd25519")
 
 	// Verify Signature
 	pubKey, err := app.GetPublicKeyEd25519(path)
-	if err != nil {
-		t.Fatalf("Detected error, err: %s\n", err.Error())
-	}
+	require.NoError(err, "GetPublicKeyEd25519")
 
-	if err != nil {
-		t.Fatalf("[GetPK] Error: " + err.Error())
-		return
-	}
-
-	message = append([]byte(coinContext), message...)
+	message = append(context, message...)
 	hash := sha512.Sum512(message)
 
 	verified := ed25519.Verify(pubKey, hash[:], signature)
-	if !verified {
-		t.Fatalf("[VerifySig] Error verifying signature")
-		return
-	}
+	require.True(verified, "ed25519.Verify")
 }
 
-func Test_Sign_Fails(t *testing.T) {
-	app, err := FindLedgerOasisApp()
-	if err != nil {
-		t.Fatalf(err.Error())
+func TestSignFails(t *testing.T) {
+	if !testUsingHardware() {
+		// The mock implementation does not return the expected
+		// error messages.
+		t.Skipf("Hardware not configured for tests")
 	}
+
+	require, assert := require.New(t), assert.New(t)
+
+	app, err := testFindLedgerOasisApp()
+	require.NoError(err, "FindLedgerOasisApp")
 	defer app.Close()
 
 	path := []uint32{44, 474, 0, 0, 5}
@@ -232,16 +174,14 @@ func Test_Sign_Fails(t *testing.T) {
 	message = append(garbage, message...)
 
 	_, err = app.SignEd25519(path, []byte(coinContext), message)
-	assert.Error(t, err)
-	errMessage := err.Error()
-	assert.Equal(t, errMessage, "Unexpected data type")
+	assert.Error(err, "Signing unexpected data types should fail")
+	assert.Equal(t, "Unexpected data type", err.Error())
 
 	message = getDummyTx()
 	garbage = []byte{65}
 	message = append(message, garbage...)
 
 	_, err = app.SignEd25519(path, []byte(coinContext), message)
-	assert.Error(t, err)
-	errMessage = err.Error()
-	assert.Equal(t, errMessage, "Unexpected CBOR EOF")
+	assert.Error(err, "Signing truncated CBOR payloads should fail")
+	assert.Equal("Unexpected CBOR EOF", err.Error())
 }

--- a/internal/common_test.go
+++ b/internal/common_test.go
@@ -17,7 +17,7 @@ func getDummyTx() []byte {
 	return tx
 }
 
-func Test_PrintVersion(t *testing.T) {
+func TestPrintVersion(t *testing.T) {
 	require := require.New(t)
 
 	reqVersion := VersionInfo{0, 1, 2, 3}
@@ -104,7 +104,7 @@ func validateChunks(
 	require.Equal(expected, reassembled, "Reconstructed message should match")
 }
 
-func Test_ChunkGeneration(t *testing.T) {
+func TestChunkGeneration(t *testing.T) {
 	require := require.New(t)
 
 	bip44Path := []uint32{44, 123, 0, 0, 0}
@@ -120,7 +120,7 @@ func Test_ChunkGeneration(t *testing.T) {
 	validateChunks(t, require, pathBytes, context, message, chunks, userMessageChunkSize)
 }
 
-func Test_ChunkGeneration2(t *testing.T) {
+func TestChunkGeneration2(t *testing.T) {
 	require := require.New(t)
 
 	bip44Path := []uint32{44, 123, 0, 0, 0}
@@ -141,7 +141,7 @@ func Test_ChunkGeneration2(t *testing.T) {
 	require.Len(chunks, 5, "incorrect number of chunks")
 }
 
-func Test_ChunkGeneration_invalidContextLength(t *testing.T) {
+func TestChunkGenerationInvalidContextLength(t *testing.T) {
 	require := require.New(t)
 
 	bip44Path := []uint32{44, 123, 0, 0, 0}
@@ -157,7 +157,7 @@ func Test_ChunkGeneration_invalidContextLength(t *testing.T) {
 	t.Logf("Error: %v", err)
 }
 
-func Test_ChunkGeneration_contextLengthIsZero(t *testing.T) {
+func TestChunkGenerationContextLengthIsZero(t *testing.T) {
 	require := require.New(t)
 
 	bip44Path := []uint32{44, 123, 0, 0, 0}

--- a/internal/oasis_mock_test.go
+++ b/internal/oasis_mock_test.go
@@ -1,0 +1,220 @@
+package internal
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	ledger_go "github.com/zondax/ledger-go"
+)
+
+const (
+	testUseHardware = "OASIS_LEDGER_USE_HARDWARE"
+	headerSize      = 5
+	pathSize        = 5 * 4
+)
+
+var (
+	_ ledger_go.LedgerDevice = (*MockOasisLedger)(nil)
+
+	// Yes it would be better to derive these since we know the mnemonic
+	// but dealing with BIP-44 and BIP-32 looked annoying.
+	//
+	// For now, just hard code the expected responses in a table, with
+	// the caveat that it is not possible to test signing, and a bunch
+	// of keys have placeholder addresses due to laziness.
+	//
+	// Ledger Test Mnemonic: equip will roof matter pink blind book anxiety banner elbow sun young
+	testDeviceKeys = []*mockKeys{
+		{
+			decX("97e72e6e83ec39eb98d7e9189513aba662a08a210b9974b0f7197458483c7161"),
+			"oasis1jlnjum5rasu7hxxhayvf2yat5e32pz3ppwvhfv8hr969sjpuw9sgn54g9",
+		},
+		{
+			decX("54e98ea8afcf1321eddd2c91ee71f7f9237c38bd8c3242057be5c7ce3f46abbd"),
+			"test key address 1",
+		},
+		{
+			decX("7d10a11e1a4ef5adea33eb9f3332c6d221c12d461299de32d10e6cfffcd776d8"),
+			"test key address 2",
+		},
+		{
+			decX("00f3a005092933e8c2956d7ece62cbd39718678e35bf2a7370c344e9e755bc18"),
+			"test key address 3",
+		},
+		{
+			decX("3c713b1b2623c3a1c997b7b80c9dce4c49bf32c36dabb5cea6ce2cb6e89eb600"),
+			"test key address 4",
+		},
+		{
+			decX("636586ccbca4c1a5035552faccbce3b6ca59e6181ce17a3d84bcf6d9c5d120d1"),
+			"test key address 5",
+		},
+		{
+			decX("887fca7f936cad2733c6c8100c2ca8c612a37b9c7645b4a4b58445e5ceb6e862"),
+			"test key address 6",
+		},
+		{
+			decX("e2c22521953488a0135a4348dfd7544ff8ecfa1744fda1bef2f935476b909115"),
+			"test key address 7",
+		},
+		{
+			decX("5fec8d7031821c0a7ebbc18bdcaad826e1cf83323e172ce0a4f36a8e04792696"),
+			"test key address 8",
+		},
+		{
+			decX("72fde11509927324be809cdc815b258678ea74b2aa1d5e5490a960acd86c7a7e"),
+			"test key address 9",
+		},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		{
+			// WARNING: The relevant app test uses `account = 5`, for this
+			// test key.
+			decX("d71c79ffd5a6d438de89c833e00222a2e80ed94e9929350ef7c1c97d1d13295d"),
+			"oasis16uw8nl745m2r3h5feqe7qq3z5t5qak2wny5n2rhhc8yh68gn99wwcq4ef",
+		},
+	}
+)
+
+type mockKeys struct {
+	publicKey []byte
+	address   string
+}
+
+type MockOasisLedger struct {
+	isClosed bool
+}
+
+func (dev *MockOasisLedger) Exchange(command []byte) ([]byte, error) {
+	if dev.isClosed {
+		return nil, os.ErrClosed
+	}
+
+	cmdLen := len(command)
+	if cmdLen < headerSize {
+		return nil, fmt.Errorf("oasis/ledger/mock: truncated command: %d", cmdLen)
+	}
+
+	// command[0] = CLA (ignored for now)
+	// command[1] = instrution
+	// command[2] = parameter 1
+	// command[3] = parameter 2
+	// command[4] = payload length
+	switch command[1] {
+	case insGetVersion:
+		return dev.onGetVersion(command)
+	case insGetAddrEd25519:
+		return dev.onGetAddrEd25519(command)
+	case insSignEd25519:
+		return nil, fmt.Errorf("oasis/ledger/mock: sign not implemented yet")
+	default:
+		return nil, fmt.Errorf("oasis/ledger/mock: invalid command: %d", command[1])
+	}
+}
+
+func (dev *MockOasisLedger) onGetVersion(cmd []byte) ([]byte, error) {
+	return []byte{0x00, 0x00, 0x0d, 0x00, 0x00}, nil
+}
+
+func (dev *MockOasisLedger) onGetAddrEd25519(cmd []byte) ([]byte, error) {
+	pathLen := int(cmd[4])
+	if len(cmd) != headerSize+pathLen {
+		return nil, fmt.Errorf("oasis/ledger/mock: truncated GetAddrEd25519: %d", len(cmd))
+	}
+	if pathLen != pathSize {
+		return nil, fmt.Errorf("oasis/ledger/mock: truncated bip44 path: %d", pathLen)
+	}
+
+	path, err := parseBip44Path(cmd[headerSize:])
+	if err != nil {
+		return nil, err
+	}
+
+	addressIndex := int(path[4])
+	if addressIndex >= len(testDeviceKeys) || testDeviceKeys[addressIndex] == nil {
+		return nil, fmt.Errorf("oasis/ledger/mock: no key for address_index: %d", addressIndex)
+	}
+
+	key := testDeviceKeys[addressIndex]
+	resp := append([]byte{}, key.publicKey...)
+	resp = append(resp, []byte(key.address)...)
+
+	return resp, nil
+}
+
+func (dev *MockOasisLedger) Close() error {
+	if dev.isClosed {
+		return os.ErrClosed
+	}
+	dev.isClosed = true
+	return nil
+}
+
+func parseBip44Path(rawPath []byte) ([]uint32, error) {
+	pathLen := len(rawPath)
+	if pathLen != pathSize {
+		return nil, fmt.Errorf("oasis/ledger/mock: truncated BIP44 path: %d", pathLen)
+	}
+
+	var path [5]uint32
+	for i := range path {
+		// Just unharden so the cheesy lookup table full of keys works.
+		path[i] = binary.LittleEndian.Uint32(rawPath[i*4:]) & (^uint32(0x80000000))
+	}
+
+	return path[:], nil
+}
+
+func testFindLedgerOasisApp() (*LedgerOasis, error) {
+	if testUsingHardware() {
+		return FindLedgerOasisApp()
+	}
+
+	return newLedgerOasis(&MockOasisLedger{}, LedgerAppMode(0)), nil
+}
+
+func testUsingHardware() bool {
+	return os.Getenv(testUseHardware) == "1"
+}
+
+func decX(s string) []byte {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		panic(err)
+	}
+
+	return b
+}
+
+func checkTestKey(t *testing.T, pubKey []byte, address string, path []uint32) {
+	index := int(path[4])
+	if index >= len(testDeviceKeys) || testDeviceKeys[index] == nil {
+		t.Fatalf("no known key for address index: %d", index)
+	}
+
+	key := testDeviceKeys[index]
+
+	t.Logf("Public key %d: %x\n", index, pubKey)
+
+	require := require.New(t)
+	require.Len(pubKey, 32, "Public key should have expected length")
+	require.Equal(key.publicKey, pubKey, "Public key should match %v", path)
+	if address != "" {
+		t.Logf("Bech32 addr %d: %s\n", index, address)
+
+		require.Equal(key.address, address, "Address should match %v", path)
+	}
+}


### PR DESCRIPTION
 * Match the oasis-core test style
 * Exercise some of the code without a ledger device

The mock implementation is rather limited, but extending it further is
somewhat annoying to do and the integration wrapper is just a thin
layer anyway so there probably isn't much point.

Note: This assumes the user will set `OASIS_LEDGER_USE_HARDWARE="1"` to
test with an actual device.

Part of #20 