### PR TITLE
ledger-signer: Don't try to split cfgStr if none is specified

### DIFF
--- a/ledger-signer/ledger_signer.go
+++ b/ledger-signer/ledger_signer.go
@@ -49,7 +49,12 @@ type pluginConfig struct {
 }
 
 func newPluginConfig(cfgStr string) (*pluginConfig, error) {
-	kvStrs := strings.Split(cfgStr, ";")
+	var kvStrs []string
+
+	// Don't try to split cfgStr if no configuration is specified.
+	if cfgStr != "" {
+		kvStrs = strings.Split(cfgStr, ";")
+	}
 
 	var (
 		cfg                      pluginConfig


### PR DESCRIPTION
This should give a better error message when the user didn't specify a valid signer configuration, i.e. it will return "address not configured" instead of "malformed k/v pair: ''".

<strike>
The second commit is an implementation of this part of https://github.com/oasisprotocol/oasis-core/issues/3134:

> If the Ledger signer plugin is used, it could display something like:
>
> `Please, follow the instructions on your Ledger device's screen...`
</strike>

Removed that commit, replaced by https://github.com/oasisprotocol/oasis-core/pull/3149/commits/fa213e7a1aa433688ed5daaa6643debeaacad18e.