### PR TITLE
ledger-signer: Add `--version`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,22 @@
 include common.mk
 
+# Check if Go's linkers flags are set in common.mk and add them as extra flags.
+ifneq ($(GOLDFLAGS),)
+	GO_EXTRA_FLAGS += -ldflags $(GOLDFLAGS)
+endif
+
 # Set all target as the default target.
 all: build build-plugin
 
 # Build.
 build:
 	@$(ECHO) "$(MAGENTA)*** Building Go code...$(OFF)"
-	@$(GO) build -trimpath -v .
+	@$(GO) build $(GOFLAGS) .
 
 # Build plugin.
 build-plugin:
 	@$(ECHO) "$(MAGENTA)*** Building ledger signer plugin code...$(OFF)"
-	@$(GO) build -trimpath -v -o ./ledger-signer/ledger-signer ./ledger-signer
+	@$(GO) build $(GOFLAGS) $(GO_EXTRA_FLAGS) -o ./ledger-signer/ledger-signer ./ledger-signer
 
 # Format code.
 fmt:

--- a/ledger-signer/ledger_signer.go
+++ b/ledger-signer/ledger_signer.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"strconv"
 	"strings"
@@ -13,6 +14,10 @@ import (
 )
 
 var (
+	// SoftwareVersion represents the Oasis Core's version and should be set
+	// by the linker.
+	SoftwareVersion = "0.0-unset"
+
 	// signerPathCoinType is set to 474, the number associated with Oasis ROSE.
 	signerPathCoinType uint32 = 474
 	// signerPathAccount is the account index used to sign transactions.
@@ -41,6 +46,8 @@ var (
 		signature.SignerEntity:    signerEntityDerivationRootPath,
 		signature.SignerConsensus: signerConsensusDerivationRootPath,
 	}
+
+	versionFlag = flag.Bool("version", false, "Print version and exit")
 )
 
 type pluginConfig struct {
@@ -221,6 +228,12 @@ func (pl *ledgerPlugin) signerForRole(role signature.SignerRole) (*ledgerSigner,
 }
 
 func main() {
+	flag.Parse()
+	if *versionFlag {
+		fmt.Printf("Version: %s\n", SoftwareVersion)
+		return
+	}
+
 	// Signer plugins use raw contexts.
 	signature.UnsafeAllowUnregisteredContexts()
 


### PR DESCRIPTION
This is automagically set by git, exactly how oasis-core does things.
However instead of importing the oasis-core's version package this opts
to do the simple thing and just have a string in the package main, as
this avoids pulling in tendermint at build time.

Fixes #21.