### PR TITLE
cmd: Prevent duplicate error messages

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
@@ -37,7 +38,7 @@ func Execute() {
 	}
 
 	if err := rootCmd.Execute(); err != nil {
-		common.EarlyLogAndExit(err)
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
[`cobra.Command.Execute()`](https://github.com/spf13/cobra/blob/v1.0.0/command.go#L933) already prints the error to stderr, so we shouldn't duplicate it.