### PR TITLE
Improve the way Ledger devices/apps are identified

### DIFF
--- a/.changelog/27.breaking.md
+++ b/.changelog/27.breaking.md
@@ -1,0 +1,4 @@
+Change identification of devices to use wallet IDs instead of App Addresses
+
+The new wallet IDs are six-characters hex strings deterministically derived
+from the mnemonics the Ledger devices were initialized with.

--- a/.changelog/46.feature.2.md
+++ b/.changelog/46.feature.2.md
@@ -1,0 +1,1 @@
+cmd: Improve listing of available devices

--- a/.changelog/46.feature.md
+++ b/.changelog/46.feature.md
@@ -1,0 +1,7 @@
+common/wallet: Initial implementation of the wallet ID
+
+Wallet ID is computed as a truncated hash of a public key for a specific BIP32
+path.
+
+This means that two wallet IDs will be the same if and only if both Ledger
+devices were initialized with the same mnemonic.

--- a/.changelog/46.internal.1.md
+++ b/.changelog/46.internal.1.md
@@ -1,0 +1,7 @@
+internal: Rename functions for listing and connecting to Oasis Ledger Apps
+
+Renames:
+
+- `ListOasisDevices()` -> `ListApps()`
+- `ConnectLedgerOasisApp()` -> `ConnectApp()`
+- `FindLedgerOasisApp()` -> `FindApp()`

--- a/.changelog/46.internal.2.md
+++ b/.changelog/46.internal.2.md
@@ -1,0 +1,4 @@
+internal: Add `AppInfo` type
+
+Refactor `ListApps()` to return a list of `AppInfo` pointers and leave the
+presentation of application information to the callers.

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/oasisprotocol/oasis-core-ledger/internal"
@@ -8,10 +10,13 @@ import (
 
 var listCmd = &cobra.Command{
 	Use:   "list_devices",
-	Short: "list available devices by address",
+	Short: "list available devices",
 	Run:   doList,
 }
 
 func doList(cmd *cobra.Command, args []string) {
-	internal.ListOasisDevices(internal.ListingDerivationPath)
+	for _, appInfo := range internal.ListApps(internal.ListingDerivationPath) {
+		fmt.Printf("- Wallet ID: %s\n", appInfo.WalletID)
+		fmt.Printf("  App version: %s\n", appInfo.Version)
+	}
 }

--- a/common/wallet/id.go
+++ b/common/wallet/id.go
@@ -1,0 +1,78 @@
+package wallet
+
+import (
+	"bytes"
+	"encoding"
+	"encoding/hex"
+	"errors"
+
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+)
+
+const (
+	// IDSize is the size of a wallet ID in bytes.
+	// NOTE: The length of wallet ID's string is IDSize * 2.
+	IDSize = 3
+)
+
+var (
+	// ErrMalformedID is the error returned when a wallet ID is malformed.
+	ErrMalformedID = errors.New("wallet: malformed ID")
+
+	_ encoding.BinaryMarshaler   = ID{}
+	_ encoding.BinaryUnmarshaler = (*ID)(nil)
+)
+
+// ID is a wallet ID computed as a truncated hash of a public key for a specific
+// BIP32 path.
+type ID [IDSize]byte
+
+// MarshalBinary encodes a wallet ID into binary form.
+func (id ID) MarshalBinary() (data []byte, err error) {
+	data = append([]byte{}, id[:]...)
+	return
+}
+
+// UnmarshalBinary decodes a binary marshaled wallet ID.
+func (id *ID) UnmarshalBinary(data []byte) error {
+	if len(data) != IDSize {
+		return ErrMalformedID
+	}
+	copy(id[:], data)
+	return nil
+}
+
+// UnmarshalHex deserializes a hexadecimal text string into wallet ID.
+func (id *ID) UnmarshalHex(text string) error {
+	b, err := hex.DecodeString(text)
+	if err != nil {
+		return err
+	}
+	return id.UnmarshalBinary(b)
+}
+
+// Equal compares vs another wallet ID for equality.
+func (id ID) Equal(cmp ID) bool {
+	return bytes.Equal(id[:], cmp[:])
+}
+
+// String returns the string representation of a wallet ID.
+func (id ID) String() string {
+	return hex.EncodeToString(id[:])
+}
+
+// IsValid checks whether a wallet ID is well-formed.
+func (id ID) IsValid() bool {
+	return len(id) == IDSize
+}
+
+// NewID creates a new wallet ID the given data.
+func NewID(data []byte) (id ID) {
+	h := hash.NewFromBytes(data)
+	truncatedHash, err := h.Truncate(IDSize)
+	if err != nil {
+		panic(err)
+	}
+	_ = id.UnmarshalBinary(truncatedHash)
+	return
+}

--- a/internal/app_test.go
+++ b/internal/app_test.go
@@ -16,7 +16,7 @@ func TestFindLedger(t *testing.T) {
 
 	require := require.New(t)
 
-	app, err := FindLedgerOasisApp()
+	app, err := FindApp()
 	require.NoError(err, "FindLedgerOasisApp")
 	require.NotNil(app, "Must find a ledger device and initialize the interface")
 

--- a/internal/oasis_mock_test.go
+++ b/internal/oasis_mock_test.go
@@ -180,7 +180,7 @@ func parseBip44Path(rawPath []byte) ([]uint32, error) {
 
 func testFindLedgerOasisApp() (*LedgerOasis, error) {
 	if testUsingHardware() {
-		return FindLedgerOasisApp()
+		return FindApp()
 	}
 
 	return newLedgerOasis(&MockOasisLedger{}, LedgerAppMode(0)), nil

--- a/ledger-signer/ledger_signer.go
+++ b/ledger-signer/ledger_signer.go
@@ -58,7 +58,7 @@ func newPluginConfig(cfgStr string) (*pluginConfig, error) {
 
 	// Don't try to split cfgStr if no configuration is specified.
 	if cfgStr != "" {
-		kvStrs = strings.Split(cfgStr, ";")
+		kvStrs = strings.Split(cfgStr, ",")
 	}
 
 	var (
@@ -66,7 +66,7 @@ func newPluginConfig(cfgStr string) (*pluginConfig, error) {
 		foundWalletID, foundIndex bool
 	)
 	for _, v := range kvStrs {
-		spl := strings.Split(v, "=")
+		spl := strings.Split(v, ":")
 		if len(spl) != 2 {
 			return nil, fmt.Errorf("malformed k/v pair: '%s'", v)
 		}

--- a/ledger-signer/ledger_signer_test.go
+++ b/ledger-signer/ledger_signer_test.go
@@ -17,7 +17,7 @@ func TestNewFactoryConfig(t *testing.T) {
 		index:    17,
 	}
 
-	cfgStr := fmt.Sprintf("wallet_id=%s;index=%d", expectedConfig.walletID, expectedConfig.index)
+	cfgStr := fmt.Sprintf("wallet_id:%s,index:%d", expectedConfig.walletID, expectedConfig.index)
 	cfg, err := newPluginConfig(cfgStr)
 	require.NoError(err, "newPluginConfig")
 	require.Equal(expectedConfig, cfg, "config should parse")

--- a/ledger-signer/ledger_signer_test.go
+++ b/ledger-signer/ledger_signer_test.go
@@ -5,17 +5,19 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-core-ledger/common/wallet"
 )
 
 func TestNewFactoryConfig(t *testing.T) {
 	require := require.New(t)
 
 	expectedConfig := &pluginConfig{
-		address: "1640 Riverside Drive",
-		index:   17,
+		walletID: wallet.NewID([]byte("1640 Riverside Drive")),
+		index:    17,
 	}
 
-	cfgStr := fmt.Sprintf("address=%s;index=%d", expectedConfig.address, expectedConfig.index)
+	cfgStr := fmt.Sprintf("wallet_id=%s;index=%d", expectedConfig.walletID, expectedConfig.index)
 	cfg, err := newPluginConfig(cfgStr)
 	require.NoError(err, "newPluginConfig")
 	require.Equal(expectedConfig, cfg, "config should parse")


### PR DESCRIPTION
Introduce the notion of _wallet ID_ which is computed as a truncated hash of a public key for a specific BIP32 path.

This means a Ledger device initialized with the same mnemonic will return the same wallet ID.

Change identification of Ledger wallets via _App Addresses_ to wallet IDs.

Closes #27.