### PR TITLE
ledger-signer: Fix discovery when using a non-zero index

### DIFF
--- a/.changelog/54.bugfix.md
+++ b/.changelog/54.bugfix.md
@@ -1,0 +1,1 @@
+ledger-signer: Fix discovery when using a non-zero index

--- a/ledger-signer/ledger_signer.go
+++ b/ledger-signer/ledger_signer.go
@@ -154,7 +154,7 @@ func (pl *ledgerPlugin) Load(role signature.SignerRole, _mustGenerate bool) erro
 		return nil
 	}
 
-	dev, err := internal.ConnectApp(pl.walletID, signer.path)
+	dev, err := internal.ConnectApp(pl.walletID, internal.ListingDerivationPath)
 	if err != nil {
 		return fmt.Errorf("ledger: failed to connect to device: %w", err)
 	}


### PR DESCRIPTION
Fixes #54 