### PR TITLE
internal: Ignore Punch's version file when running towncrier check

### DIFF
--- a/.changelog/56.internal.md
+++ b/.changelog/56.internal.md
@@ -1,0 +1,1 @@
+Ignore Punch's version file when running towncrier check

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -5,6 +5,11 @@
 [tool.towncrier]
 filename = "CHANGELOG.md"
 directory = ".changelog"
+# Ignore certain files when running towncrier check.
+check_ignore_files = [
+  # Punch's version file.
+  ".punch_version.py",
+]
 issue_format = "[#{issue}](https://github.com/oasisprotocol/oasis-core-ledger/issues/{issue})"
 start_string = "<!-- TOWNCRIER -->\n"
 # Custom Jinja2 template for preparing a new section of the Change Log.


### PR DESCRIPTION
It is bumped automatically and would mislead towncrier into reporting that a Change Log fragment is needed when assembling the Change Log for a new release.