### PR TITLE
internal: Ensure staking account address computation matches

### DIFF
--- a/.changelog/58.internal.2.md
+++ b/.changelog/58.internal.2.md
@@ -1,0 +1,4 @@
+internal: Refactor public key handling in mocked tests
+
+Rename `mockKeys` type to `mockKey` and add methods that automatically compute
+the corresponding raw public key and raw staking account address.

--- a/.changelog/58.internal.md
+++ b/.changelog/58.internal.md
@@ -1,0 +1,5 @@
+internal: Add check that ensures staking account address computation matches
+
+This makes Oasis Core Ledger fail if the staking account address computed on
+the device doesn't match the staking account address computed via Oasis Core's
+functions.

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -81,6 +81,11 @@ jobs:
           version: v1.28
         # Always run this step so that all linting errors can be seen at once.
         if: always()
+      - name: Ensure a clean code checkout
+        uses: actions/checkout@v2
+        with:
+          clean: true
+        if: always()
       - name: Check go mod tidy
         run: |
           make lint-go-mod-tidy

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,7 @@ github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13P
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190207003914-4c204d697803/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
+github.com/btcsuite/btcutil v1.0.2 h1:9iZ1Terx9fMIOtq1VrwdqfsATL9MC2l8ZrUY6YZ2uts=
 github.com/btcsuite/btcutil v1.0.2/go.mod h1:j9HUFwoQRsZL3V4n+qG+CUnEGHOarIxfC3Le2Yhbcts=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd/go.mod h1:HHNXQzUsZCxOoE+CPiyCTO6x34Zs86zZUiwtpXoGdtg=
 github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVaaLLH7j4eDXPRvw78tMflu7Ie2bzYOH4Y8rRKBY=


### PR DESCRIPTION
This should prevent using Oasis Core Ledger with an Oasis App that computes the staking account address differently from Oasis Core.