### PR TITLE
cmd: Add show_address CLI command

### DIFF
--- a/.changelog/59.feature.md
+++ b/.changelog/59.feature.md
@@ -1,0 +1,1 @@
+cmd: Add `show_address` CLI command for obtaining a wallet's account address

--- a/cmd/address.go
+++ b/cmd/address.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
+
+	"github.com/oasisprotocol/oasis-core-ledger/common/wallet"
+	"github.com/oasisprotocol/oasis-core-ledger/internal"
+)
+
+const (
+	// cfgWalletID configures wallet ID.
+	cfgWalletID = "wallet_id"
+
+	// cfgIndex configures the wallet's account index (0-based).
+	cfgIndex = "index"
+
+	// cfgDontShowOnDevice configures whether staking account address should not
+	// be shown on device's screen.
+	cfgDontShowOnDevice = "no-show"
+)
+
+var (
+	showAddressFlags = flag.NewFlagSet("", flag.ContinueOnError)
+
+	showAddressCmd = &cobra.Command{
+		Use:   "show_address",
+		Short: "show staking account address",
+		Run:   doShowAddress,
+	}
+
+	logger = logging.GetLogger("cmd")
+)
+
+func doShowAddress(cmd *cobra.Command, args []string) {
+	var walletID wallet.ID
+	if err := walletID.UnmarshalHex(viper.GetString(cfgWalletID)); err != nil {
+		logger.Error("failed to parse wallet ID",
+			"err", err,
+		)
+		os.Exit(1)
+	}
+
+	index := viper.GetUint32(cfgIndex)
+	path := internal.GetPath(index)
+
+	app, err := internal.ConnectApp(walletID, internal.ListingDerivationPath)
+	if err != nil {
+		logger.Error("failed to connect to ledger device",
+			"wallet_id", walletID,
+			"err", err,
+		)
+		os.Exit(1)
+	}
+
+	_, address, err := app.GetAddressPubKeyEd25519(path)
+	if err != nil {
+		logger.Error("failed to get account address",
+			"wallet_id", walletID,
+			"index", index,
+			"err", err,
+		)
+		os.Exit(1)
+	}
+
+	fmt.Println(address)
+
+	if !viper.GetBool(cfgDontShowOnDevice) {
+		fmt.Fprintln(os.Stderr, "Ensure account address shown on device's screen matches the outputted address.")
+		_, _, err = app.ShowAddressPubKeyEd25519(path)
+		if err != nil {
+			logger.Error("failed to show account address",
+				"wallet_id", walletID,
+				"index", index,
+				"err", err,
+			)
+			os.Exit(1)
+		}
+	}
+}
+
+func init() { //nolint:gochecknoinits
+	showAddressFlags.String(cfgWalletID, "", "wallet ID")
+	showAddressFlags.Uint32(cfgIndex, 0, "wallet's account index (0-based) (default 0)")
+	showAddressFlags.Bool(cfgDontShowOnDevice, false, "don't show account address on device")
+	_ = viper.BindPFlags(showAddressFlags)
+
+	showAddressCmd.Flags().AddFlagSet(showAddressFlags)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,4 +57,5 @@ func init() { // nolint: gochecknoinits
 
 	// Register all of the sub-commands.
 	rootCmd.AddCommand(listCmd)
+	rootCmd.AddCommand(showAddressCmd)
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ It provides:
 
 - [Setup](usage/setup.md)
 - [Identifying Ledger devices](usage/devices.md)
+- [Obtaining Account Address](usage/address.md)
 - [Exporting Public Key to Entity](usage/entity.md)
 - [Generating and Signing Transactions](usage/transactions.md)
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -6,6 +6,7 @@
 
 - [Setup](usage/setup.md)
 - [Identifying Ledger devices](usage/devices.md)
+- [Obtaining Account Address](usage/address.md)
 - [Exporting Public Key to Entity](usage/entity.md)
 - [Generating and Signing Transactions](usage/transactions.md)
 

--- a/docs/usage/address.md
+++ b/docs/usage/address.md
@@ -1,0 +1,31 @@
+# Obtaining Account Address
+
+Each account on your Ledger wallet has a corresponding
+[staking account address].
+
+To obtain a staking account address that corresponds to the account with index
+0 on your Ledger wallet, use:
+
+```bash
+oasis-core-ledger show_address --wallet_id <LEDGER-WALLET-ID>
+```
+
+where `<LEDGER-WALLET-ID>` is replaced with the ID of your Ledger wallet.
+
+See [Identifying Ledger Devices] for more details.
+
+This will display your wallet's address and show it on your Ledger's screen for
+confirmation.
+
+To just display your wallet's address without showing it on your Ledger's
+screen, pass the `--no-show` flag in the command above.
+
+{% hint style="info" %}
+You can obtain as many staking account addresses as needed for the same Ledger
+wallet by passing the `--index` flag and specifying a different account index in
+the command above.
+{% endhint %}
+
+[staking account address]:
+  https://docs.oasis.dev/general/use-your-tokens/account/address
+[Identifying Ledger Devices]: devices.md

--- a/internal/app.go
+++ b/internal/app.go
@@ -113,6 +113,13 @@ func getModeForPath(path []uint32) LedgerAppMode {
 	}
 }
 
+// GetPath returns the BIP32 path for the given account index.
+func GetPath(index uint32) []uint32 {
+	return []uint32{
+		PathPurposeBIP44, ListingPathCoinType, ListingPathAccount, ListingPathChange, index,
+	}
+}
+
 // ListApps returns a list of Oasis Ledger Apps that could be connected to.
 func ListApps(path []uint32) []*AppInfo {
 	ledgerAdmin := ledger_go.NewLedgerAdmin()


### PR DESCRIPTION
TODO:
- [x] Add docs.
- [x] Consider reversing the `--show` flag to `--no-show` so that it can be set to `false` by default which makes its use a little more intuitive, e.g. users will need to just pass `show_address --no-show` instead of the longer `show_address --show=false` version.

Closes #53.