### PR TITLE
release: Add macOS builds

### DIFF
--- a/.changelog/65.feature.md
+++ b/.changelog/65.feature.md
@@ -1,0 +1,1 @@
+release: Add macOS builds

--- a/.changelog/65.internal.md
+++ b/.changelog/65.internal.md
@@ -1,0 +1,1 @@
+github: Replace deprecated `set-env` workflow command with environment file

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,63 @@ on:
       # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#patterns-to-match-branches-and-tags.
       - 'v[0-9]+.[0-9]+*'
 
+# Global environment variables.
+env:
+  GORELEASER_URL_PREFIX: https://github.com/goreleaser/goreleaser/releases/download/
+  GORELEASER_VERSION: 0.141.0
+  CURL_CMD: curl --proto =https --tlsv1.2 -sSL
+
 jobs:
 
+  # Build macOS release binaries and upload them.
+  build-macos:
+    # NOTE: This name appears in GitHub's Checks API.
+    name: build-macos
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          # Fetch all history as the recommended way to fetch all tags and
+          # branches of the project.
+          # This allows the release helpers in common.mk to determine the
+          # project's version from git correctly.
+          # For more info, see:
+          # https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches
+          fetch-depth: 0
+      - name: Set up Go 1.15
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.15.x"
+      - name: Install GoReleaser
+        run: |
+          cd $(mktemp -d /tmp/goreleaser.XXXXX)
+          ${CURL_CMD} ${GORELEASER_URL_PREFIX}/v${GORELEASER_VERSION}/${GORELEASER_TARBALL} \
+            --output ${GORELEASER_TARBALL}
+          tar -xf ${GORELEASER_TARBALL}
+          sudo mv goreleaser /usr/local/bin
+        env:
+          GORELEASER_TARBALL: goreleaser_Darwin_x86_64.tar.gz
+      - name: Set RELEASE_BRANCH name for stable/bugfix releases
+        run: |
+          GIT_VERSION=${GITHUB_REF#refs/tags/v}
+          if [[ $GIT_VERSION != *.0 ]]; then
+            echo "RELEASE_BRANCH=stable/${GIT_VERSION%.*}.x" >> $GITHUB_ENV
+          fi
+      - name: Build macOS binaries
+        run: |
+          make release-build-darwin
+      - name: Upload macOS binaries
+        uses: actions/upload-artifact@v2.2.0
+        with:
+          name: macos-binaries
+          path: dist/*_darwin_amd64/*
+          if-no-files-found: error
+
+  # Build Linux release binaries, download macOS release binaries and publish a
+  # release.
   prepare-release:
+    needs: build-macos
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -41,16 +95,18 @@ jobs:
           tar -xf ${GORELEASER_TARBALL}
           sudo mv goreleaser /usr/local/bin
         env:
-          GORELEASER_URL_PREFIX: https://github.com/goreleaser/goreleaser/releases/download/
-          GORELEASER_VERSION: 0.141.0
           GORELEASER_TARBALL: goreleaser_Linux_x86_64.tar.gz
-          CURL_CMD: curl --proto =https --tlsv1.2 -sSL
       - name: Set RELEASE_BRANCH name for stable/bugfix releases
         run: |
           GIT_VERSION=${GITHUB_REF#refs/tags/v}
           if [[ $GIT_VERSION != *.0 ]]; then
             echo "RELEASE_BRANCH=stable/${GIT_VERSION%.*}.x" >> $GITHUB_ENV
           fi
+      - name: Download macOS binaries
+        uses: actions/download-artifact@v2.0.5
+        with:
+          name: macos-binaries
+          path: ../macos-binaries
       - name: Build and publish the next release
         run: |
           make release-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           GIT_VERSION=${GITHUB_REF#refs/tags/v}
           if [[ $GIT_VERSION != *.0 ]]; then
-            echo ::set-env name=RELEASE_BRANCH::stable/${GIT_VERSION%.*}.x
+            echo "RELEASE_BRANCH=stable/${GIT_VERSION%.*}.x" >> $GITHUB_ENV
           fi
       - name: Build and publish the next release
         run: |

--- a/.goreleaser-darwin.yml
+++ b/.goreleaser-darwin.yml
@@ -1,23 +1,15 @@
-# GoReleaser configuration file.
+# GoReleaser configuration file for building macOS binaries.
 #
-# For more info, browse to http://goreleaser.com.
+# NOTE: Currently, GoReleaser doesn't support only building a subset of defined
+# operating systems and architectures.
+# For more details, see: https://github.com/goreleaser/goreleaser/issues/1852.
 #
-# NOTE: Cross-compiling Oasis Core Ledger binaries requires CGO to be enabled,
-# i.e. setting the CGO_ENABLED environment variable to 1.
-# This is not set in the configuration below since we use the following
-# procedure to prepare a release:
-# 1. Build (working) Oasis Core Ledger macOS binaries on macOS via Make's
-#    make release-build-darwin target.
-# 2. Build Linux and (non-working) macOS Oasis Core Ledger binaries on Linux
-#    with this configuration file.
-#    If CGO_ENABLED would be set to 1, this step would fail due to missing
-#    macOS-specific headers.
-# 3. Replace the non-working macOS Oasis Core Ledger binaries with the working
-#    ones built on macOS via a build post-hook.
-# 4. Prepare release tarballs and publish a release as normally.
+# Hence, we use this workaround of having a copy of GoReleaser's main
+# configuration file (.goreleaser.yml) and changing the 'goos' keys to only
+# contain 'darwin'.
 #
-# NOTE: The GoReleaser is not meant to be run directly, but rather through
-# Make's release-build target.
+# NOTE: This GoReleaser configuration is not meant to be run directly, but
+# rather through Make's release-build-darwin target.
 
 project_name: Oasis Core Ledger
 
@@ -38,12 +30,9 @@ builds:
       - -buildid=
       - "{{.Env.GOLDFLAGS_VERSION}}"
     goos:
-      - linux
       - darwin
     goarch:
       - amd64
-    hooks:
-      post: .scripts/goreleaser-replace-darwin-build.sh {{.Name}} {{.Target}}
 
   - id: ledger-signer
     main: ./ledger-signer/ledger_signer.go
@@ -58,12 +47,9 @@ builds:
       - -buildid=
       - "{{.Env.GOLDFLAGS_VERSION}}"
     goos:
-      - linux
       - darwin
     goarch:
       - amd64
-    hooks:
-      post: .scripts/goreleaser-replace-darwin-build.sh {{.Name}} {{.Target}}
 
 archives:
   - name_template: "{{replace .ProjectName \" \" \"_\" | tolower}}_{{.Version}}_{{.Os}}_{{.Arch}}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,6 +25,7 @@ builds:
       - "{{.Env.GOLDFLAGS_VERSION}}"
     goos:
       - linux
+      - darwin
     goarch:
       - amd64
 
@@ -42,6 +43,7 @@ builds:
       - "{{.Env.GOLDFLAGS_VERSION}}"
     goos:
       - linux
+      - darwin
     goarch:
       - amd64
 

--- a/.scripts/goreleaser-replace-darwin-build.sh
+++ b/.scripts/goreleaser-replace-darwin-build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Script that is used as a GoReleaser's build post-hook to replace non-working
+# macOS binaries built on Linux with working ones built on macOS.
+
+set -euo pipefail
+
+BUILD_NAME=$1
+BUILD_TARGET=$2
+
+REL_PATH="${BUILD_NAME}_${BUILD_TARGET}/${BUILD_NAME}"
+SRC_PATH="$PWD/../macos-binaries/$REL_PATH"
+DST_PATH="$PWD/dist/$REL_PATH"
+
+if [[ ${OASIS_CORE_LEDGER_REAL_RELEASE:-false} == true && ${BUILD_TARGET} == darwin_amd64 ]]; then
+    echo "Moving binary '$SRC_PATH' to '$DST_PATH'"
+    mv $SRC_PATH $DST_PATH
+    chmod +x $DST_PATH
+fi

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,10 @@ release-stable-branch: fetch-git
 	@git push $(OASIS_CORE_LEDGER_GIT_ORIGIN_REMOTE) $(_STABLE_BRANCH)
 	@$(ECHO) "$(CYAN)*** Branch '$(_STABLE_BRANCH)' has been sucessfully pushed to $(OASIS_CORE_LEDGER_GIT_ORIGIN_REMOTE) remote.$(OFF)"
 
+# Build macOS release binaries.
+release-build-darwin:
+	@goreleaser build --config .goreleaser-darwin.yml --rm-dist --skip-validate
+
 # Build and publish the next release.
 release-build:
 	@$(ENSURE_GIT_VERSION_EQUALS_PUNCH_VERSION)

--- a/docs/usage/setup.md
+++ b/docs/usage/setup.md
@@ -1,7 +1,7 @@
 # Setup
 
 {% hint style="warning" %}
-Oasis Core Ledger currently only works on x86_64 Linux systems.
+Oasis Core Ledger is currently only supported on x86_64 Linux and macOS systems.
 {% endhint %}
 
 ## Prerequisites
@@ -17,10 +17,21 @@ You will need an appropriate version Oasis Node CLI installed your system.
 For more details, see the [Oasis Node] documentation in the general
 [Oasis Docs].
 
+{% hint style="warning" %}
+Currently, there are no binary releases of the Oasis Node CLI for macOS systems.
+
+To be able to use the Ledger signer plugin on a macOS system, you will need to
+[build the Oasis Node CLI from source].
+{% endhint %}
+
 [Oasis Node]:
   https://docs.oasis.dev/general/run-a-node/prerequisites/oasis-node
 [Oasis Docs]:
   https://docs.oasis.dev/
+<!-- markdownlint-disable line-length -->
+[build the Oasis Node CLI from source]:
+  https://docs.oasis.dev/general/run-a-node/prerequisites/oasis-node#building-from-source
+<!-- markdownlint-enable line-length -->
 
 ## Downloading a Binary Release
 


### PR DESCRIPTION
~~TODO: figure out how to cross-compile with CGO using goreleaser. reference: https://goreleaser.com/cookbooks/cgo-and-crosscompiling~~

Avoid the complex setup of cross-compiling Oasis Core Ledger's macOS binaries on Linux due to dependencies requiring CGO.
Instead, build macOS binaries on macOS and use them when building and publishing an Oasis Core Ledger's release on Linux.