### PR TITLE
cmd: Rename show_address's no-show flag to skip-device

### DIFF
--- a/.changelog/71.feature..md
+++ b/.changelog/71.feature..md
@@ -1,0 +1,1 @@
+cmd: Add `show_address` CLI command for obtaining a wallet's account address

--- a/cmd/address.go
+++ b/cmd/address.go
@@ -21,9 +21,9 @@ const (
 	// cfgIndex configures the wallet's account index (0-based).
 	cfgIndex = "index"
 
-	// cfgDontShowOnDevice configures whether staking account address should not
-	// be shown on device's screen.
-	cfgDontShowOnDevice = "no-show"
+	// cfgSkipDevice configures whether showing staking account address on
+	// device's screen should be skipped or not.
+	cfgSkipDevice = "skip-device"
 )
 
 var (
@@ -71,7 +71,7 @@ func doShowAddress(cmd *cobra.Command, args []string) {
 
 	fmt.Println(address)
 
-	if !viper.GetBool(cfgDontShowOnDevice) {
+	if !viper.GetBool(cfgSkipDevice) {
 		fmt.Fprintln(os.Stderr, "Ensure account address shown on device's screen matches the outputted address.")
 		_, _, err = app.ShowAddressPubKeyEd25519(path)
 		if err != nil {
@@ -88,7 +88,7 @@ func doShowAddress(cmd *cobra.Command, args []string) {
 func init() { //nolint:gochecknoinits
 	showAddressFlags.String(cfgWalletID, "", "wallet ID")
 	showAddressFlags.Uint32(cfgIndex, 0, "wallet's account index (0-based) (default 0)")
-	showAddressFlags.Bool(cfgDontShowOnDevice, false, "don't show account address on device")
+	showAddressFlags.Bool(cfgSkipDevice, false, "skip showing account address on device")
 	_ = viper.BindPFlags(showAddressFlags)
 
 	showAddressCmd.Flags().AddFlagSet(showAddressFlags)

--- a/docs/usage/address.md
+++ b/docs/usage/address.md
@@ -17,8 +17,8 @@ See [Identifying Ledger Devices] for more details.
 This will display your wallet's address and show it on your Ledger's screen for
 confirmation.
 
-To just display your wallet's address without showing it on your Ledger's
-screen, pass the `--no-show` flag in the command above.
+To skip showing your wallet's address on your Ledger's screen, pass the
+`--skip-device` flag in the command above.
 
 {% hint style="info" %}
 You can obtain as many staking account addresses as needed for the same Ledger


### PR DESCRIPTION
Remove ambiguity since the command has 'show' in it and the flag is named 'no-show'.