### PR TITLE
internal: Change ConnectApp() to not always require wallet ID

### DIFF
--- a/.changelog/72.feature.2.md
+++ b/.changelog/72.feature.2.md
@@ -1,0 +1,1 @@
+ledger-signer: Make `wallet_id` configuration optional

--- a/.changelog/72.feature.md
+++ b/.changelog/72.feature.md
@@ -1,0 +1,1 @@
+cmd: Add `show_address` CLI command for obtaining a wallet's account address

--- a/.changelog/72.internal.md
+++ b/.changelog/72.internal.md
@@ -1,0 +1,1 @@
+internal: Change `ConnectApp()` to not require wallet ID in single device case

--- a/cmd/address.go
+++ b/cmd/address.go
@@ -39,12 +39,16 @@ var (
 )
 
 func doShowAddress(cmd *cobra.Command, args []string) {
-	var walletID wallet.ID
-	if err := walletID.UnmarshalHex(viper.GetString(cfgWalletID)); err != nil {
-		logger.Error("failed to parse wallet ID",
-			"err", err,
-		)
-		os.Exit(1)
+	var walletID *wallet.ID
+	hexWalletID := viper.GetString(cfgWalletID)
+	if hexWalletID != "" {
+		walletID = new(wallet.ID)
+		if err := walletID.UnmarshalHex(hexWalletID); err != nil {
+			logger.Error("failed to parse wallet ID",
+				"err", err,
+			)
+			os.Exit(1)
+		}
 	}
 
 	index := viper.GetUint32(cfgIndex)
@@ -86,7 +90,7 @@ func doShowAddress(cmd *cobra.Command, args []string) {
 }
 
 func init() { //nolint:gochecknoinits
-	showAddressFlags.String(cfgWalletID, "", "wallet ID")
+	showAddressFlags.String(cfgWalletID, "", "wallet ID (can be omitted if only a single device is connected)")
 	showAddressFlags.Uint32(cfgIndex, 0, "wallet's account index (0-based) (default 0)")
 	showAddressFlags.Bool(cfgSkipDevice, false, "skip showing account address on device")
 	_ = viper.BindPFlags(showAddressFlags)

--- a/docs/usage/address.md
+++ b/docs/usage/address.md
@@ -7,18 +7,19 @@ To obtain a staking account address that corresponds to the account with index
 0 on your Ledger wallet, use:
 
 ```bash
-oasis-core-ledger show_address --wallet_id <LEDGER-WALLET-ID>
+oasis-core-ledger show_address
 ```
-
-where `<LEDGER-WALLET-ID>` is replaced with the ID of your Ledger wallet.
-
-See [Identifying Ledger Devices] for more details.
 
 This will display your wallet's address and show it on your Ledger's screen for
 confirmation.
 
 To skip showing your wallet's address on your Ledger's screen, pass the
 `--skip-device` flag in the command above.
+
+If you have more that one Ledger wallet connected, you'll need specify which
+wallet to use by passing the `--wallet_id <LEDGER-WALLET-ID>` flag to the
+command above, replacing `<LEDGER-WALLET-ID>` with the ID of your Ledger wallet.
+See [Identifying Ledger Devices] for more details.
 
 {% hint style="info" %}
 You can obtain as many staking account addresses as needed for the same Ledger

--- a/docs/usage/devices.md
+++ b/docs/usage/devices.md
@@ -26,11 +26,5 @@ the one below:
   App version: 1.7.2
 ```
 
-From now on, use the `Wallet ID` to identify the Ledger device you want to use.
-
-For convenience, set the `LEDGER_WALLET_ID` environment value to its value,
-e.g.:
-
-```bash
-LEDGER_WALLET_ID=431fc6
-```
+You can pass this ID when you need to specify which Ledger device you want to
+connect to via `--wallet_id` CLI flag or `wallet_id` configuration key.

--- a/docs/usage/transactions.md
+++ b/docs/usage/transactions.md
@@ -9,8 +9,6 @@ Make sure you set the following environment variables:
 - `GENESIS_FILE`: Location of the genesis file.
 - `LEDGER_SIGNER_PATH`: Location of the `ledger-signer` binary.
   See [Setup] for more details.
-- `LEDGER_WALLET_ID`: ID of the Ledger wallet to use.
-  See [Identifying Ledger Devices] for more details.
 - `LEDGER_INDEX`: Index (0-based) of the account on the Ledger device to use.
 
 For convenience, you can set the `TX_FLAGS` environment variable like below:
@@ -21,9 +19,23 @@ TX_FLAGS=(--genesis.file "$GENESIS_FILE"
   --signer.backend plugin
   --signer.plugin.name ledger
   --signer.plugin.path "$LEDGER_SIGNER_PATH"
-  --signer.plugin.config "wallet_id:$LEDGER_WALLET_ID,index:$LEDGER_INDEX"
+  --signer.plugin.config "index:$LEDGER_INDEX"
 )
 ```
+
+{% hint style="info" %}
+In case you will have more than one Ledger device connected, you will need to
+specify which device to use by setting the `wallet_id` configuration key in
+the `--signer.plugin.config` flag above, separating multiple configurations with
+a comma (`,`), i.e.
+
+```
+--signer.plugin.config "index:$LEDGER_INDEX,wallet_id:<LEDGER-WALLET-ID>"
+```
+
+where `<LEDGER-WALLET-ID>` is replaced with the ID of your Ledger wallet.
+See [Identifying Ledger Devices] for more details.
+{% endhint %}
 
 Then, you can generate and sign a transaction, e.g. a transfer transaction, by
 running:

--- a/ledger-signer/ledger_signer.go
+++ b/ledger-signer/ledger_signer.go
@@ -49,7 +49,7 @@ var (
 )
 
 type pluginConfig struct {
-	walletID wallet.ID
+	walletID *wallet.ID
 	index    uint32
 }
 
@@ -77,6 +77,7 @@ func newPluginConfig(cfgStr string) (*pluginConfig, error) {
 			if foundWalletID {
 				return nil, fmt.Errorf("wallet ID already configured")
 			}
+			cfg.walletID = new(wallet.ID)
 			if err := cfg.walletID.UnmarshalHex(spl[1]); err != nil {
 				return nil, err
 			}
@@ -96,9 +97,6 @@ func newPluginConfig(cfgStr string) (*pluginConfig, error) {
 		}
 	}
 
-	if !foundWalletID {
-		return nil, fmt.Errorf("wallet ID not configured")
-	}
 	if !foundIndex {
 		return nil, fmt.Errorf("index not configured")
 	}
@@ -107,7 +105,7 @@ func newPluginConfig(cfgStr string) (*pluginConfig, error) {
 }
 
 type ledgerPlugin struct {
-	walletID wallet.ID
+	walletID *wallet.ID
 	inner    map[signature.SignerRole]*ledgerSigner
 }
 

--- a/ledger-signer/ledger_signer_test.go
+++ b/ledger-signer/ledger_signer_test.go
@@ -12,8 +12,10 @@ import (
 func TestNewFactoryConfig(t *testing.T) {
 	require := require.New(t)
 
+	walletID := wallet.NewID([]byte("1640 Riverside Drive"))
+
 	expectedConfig := &pluginConfig{
-		walletID: wallet.NewID([]byte("1640 Riverside Drive")),
+		walletID: &walletID,
 		index:    17,
 	}
 


### PR DESCRIPTION
In case there is only a single device connected to the system, don't require passing the wallet ID.

cmd: Make `show_address`' `--wallet_id` flag optional.

ledger-signer: Make `wallet_id` configuration optional.