### PR TITLE
internal: Log message sent to device separately in sign() function

### DIFF
--- a/.changelog/92.feature.md
+++ b/.changelog/92.feature.md
@@ -1,0 +1,5 @@
+internal: Log message sent to device separately in `sign()` function
+
+This simplifies debugging since message will be logged immediately after it is
+generated (and before it is sent to the device) and not together with the
+response (after response is received from the device).

--- a/internal/app.go
+++ b/internal/app.go
@@ -382,11 +382,14 @@ func (ledger *LedgerOasis) sign(bip44Path []uint32, context, transaction []byte)
 		message := []byte{ledger.getCLA(), insSignEd25519, payloadDesc, 0, payloadLen}
 		message = append(message, chunk...)
 
+		logger.Debug("Sign",
+			"message", hex.EncodeToString(message),
+		)
+
 		response, err := ledger.device.Exchange(message)
 
 		logger.Debug("Sign",
 			"err", err,
-			"message", hex.EncodeToString(message),
 			"response", hex.EncodeToString(response),
 		)
 


### PR DESCRIPTION
This simplifies debugging since message will be logged immediately after it is generated (and before it is sent to the device) and not together with the response (after response is received from the device).