### PR TITLE
internal: Add 0.1 s delay after signing to work-around Oasis app issue

### DIFF
--- a/.changelog/93.bugfix.md
+++ b/.changelog/93.bugfix.md
@@ -1,0 +1,7 @@
+internal: Add 0.1 s delay after signing to work-around Oasis app issue
+
+Add 0.1 s delay at the end of the `sign()` function to work-around Oasis app
+issue of not being capable of signing two transactions immediately one after
+another.
+
+For more details, see: <https://github.com/Zondax/ledger-oasis/issues/68>.

--- a/internal/app.go
+++ b/internal/app.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"encoding/hex"
 	"fmt"
+	"time"
 
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
@@ -405,6 +406,11 @@ func (ledger *LedgerOasis) sign(bip44Path []uint32, context, transaction []byte)
 
 		finalResponse = response
 	}
+
+	// XXX: Work-around for Oasis App issue of currently not being capable of
+	// signing two transactions immediately one after another:
+	// https://github.com/Zondax/ledger-oasis/issues/68.
+	time.Sleep(100 * time.Millisecond)
 
 	return finalResponse, nil
 }


### PR DESCRIPTION
Add 0.1 s delay at the end of the `sign()` function to work-around Oasis app issue of not being capable of signing two transactions immediately one after another.

For more details, see: <https://github.com/Zondax/ledger-oasis/issues/68>.