### PR TITLE
docs: Switch to github.com links for cross-repository .md referencing

### DIFF
--- a/.changelog/224.doc.md
+++ b/.changelog/224.doc.md
@@ -1,0 +1,3 @@
+docs: Use absolute github.com links to external markdown files
+
+This policy was introduced by oasisprotocol/docs#200.

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -77,7 +77,7 @@ jobs:
         # NOTE: Using the official golangci-lint GitHub Action should give
         # better performance than manually installing golangci-lint and running
         # 'make lint-go'.
-        uses: golangci/golangci-lint-action@v2.3.0
+        uses: golangci/golangci-lint-action@v3.2.0
         with:
           # NOTE: The version must be specified without the patch version.
           version: v1.37

--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,11 @@ lint-go:
 lint-git:
 	@$(CHECK_GITLINT)
 
+# Lint documentation.
+# Ignore CHANGELOG.md, since it's composed from .changelog snippets.
 lint-docs:
-	@$(ECHO) "$(CYAN)*** Runnint markdownlint-cli...$(OFF)"
-	@npx markdownlint-cli '**/*.md' --ignore .changelog/
+	@$(ECHO) "$(CYAN)*** Running markdownlint-cli...$(OFF)"
+	@npx markdownlint-cli '**/*.md' --ignore .changelog/ --ignore CHANGELOG.md
 
 lint-changelog:
 	@$(CHECK_CHANGELOG_FRAGMENTS)

--- a/docs/usage/address.md
+++ b/docs/usage/address.md
@@ -53,8 +53,10 @@ to the [BIP44] specification.
 
 :::
 
+<!-- markdownlint-disable line-length -->
 [staking account address]:
-  /general/manage-tokens/terminology#address
+  https://github.com/oasisprotocol/docs/blob/main/docs/general/manage-tokens/terminology.md#address
 [Identifying Wallets]: wallets.md
 [BIP32]: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
 [BIP44]: https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
+<!-- markdownlint-enable line-length -->

--- a/docs/usage/setup.md
+++ b/docs/usage/setup.md
@@ -28,10 +28,12 @@ To be able to use the Ledger signer plugin on a macOS system, you will need to
 
 :::
 
-[Oasis Node]: /general/run-a-node/prerequisites/oasis-node
-[Oasis Docs]: /
 <!-- markdownlint-disable line-length -->
-[build the Oasis Node CLI from source]: /general/run-a-node/prerequisites/oasis-node#building-from-source
+[Oasis Node]:
+  https://github.com/oasisprotocol/docs/blob/main/docs/node/run-your-node/prerequisites/oasis-node.md
+[Oasis Docs]: https://github.com/oasisprotocol/docs/blob/main/docs/general/README.mdx
+[build the Oasis Node CLI from source]:
+  https://github.com/oasisprotocol/docs/blob/main/docs/node/run-your-node/prerequisites/oasis-node.md#building-from-source
 <!-- markdownlint-enable line-length -->
 
 ## Downloading a Binary Release

--- a/docs/usage/transactions.md
+++ b/docs/usage/transactions.md
@@ -169,15 +169,17 @@ For more details, see the [Transfer Tokens] document of the general
 :::
 
 <!-- markdownlint-disable line-length -->
-[Use Your Tokens' Setup]: /general/manage-tokens/advanced/oasis-cli-tools
-[Oasis Docs]: /
+[Use Your Tokens' Setup]:
+  https://github.com/oasisprotocol/docs/blob/main/docs/general/manage-tokens/advanced/oasis-cli-tools/README.md
+[Oasis Docs]:
+  https://github.com/oasisprotocol/docs/blob/main/docs/general/README.mdx
 [Base and Signer CLI flags]:
-  /general/manage-tokens/advanced/oasis-cli-tools/setup#common-cli-flags
+  https://github.com/oasisprotocol/docs/blob/main/docs/general/manage-tokens/advanced/oasis-cli-tools/setup.md#common-cli-flags
 [Common Transaction Flags]:
-  /general/manage-tokens/advanced/oasis-cli-tools/setup#common-transaction-flags
+  https://github.com/oasisprotocol/docs/blob/main/docs/general/manage-tokens/advanced/oasis-cli-tools/setup.md#common-transaction-flags
 [Setup]: setup.md#remembering-path-to-ledger-signer-plugin
 [Exporting Public Key to Entity]: entity.md
 [Identifying Wallets]: wallets.md
 [Transfer Tokens]:
-  /general/manage-tokens/advanced/oasis-cli-tools/transfer-tokens
+  https://github.com/oasisprotocol/docs/blob/main/docs/general/manage-tokens/advanced/oasis-cli-tools/transfer-tokens.md
 <!-- markdownlint-enable line-length -->


### PR DESCRIPTION
This PR:
- switches to github.com links for cross-repository .md referencing. See oasisprotocol/docs#200
- removes CHANGELOG.md from linting, because it contains indirect references with the same id across multiple changelog snippets which is not valid
- bumps `golangci-lint-action` to v3.2.0, because the existing v2.3.0 is not compatible with go1.19 anymore used by the action
