### PR TITLE
docs: Migrate docs.oasis.dev -> docs.oasis.io

### DIFF
--- a/.changelog/227.trivial.md
+++ b/.changelog/227.trivial.md
@@ -1,0 +1,1 @@
+docs: Migrate docs.oasis.dev -> docs.oasis.io

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It provides:
 
 ## Documentation
 
-Browse to [docs.oasis.dev/oasis-core-ledger][docs].
+Browse to [docs.oasis.io/oasis-core-ledger][docs].
 
 ## Contributing
 
@@ -42,6 +42,6 @@ This project is work in progress. Some aspects are subject to change.
 
 [Ledger]: https://www.ledger.com/
 [Oasis Core]: https://github.com/oasisprotocol/oasis-core
-[docs]: /oasis-core-ledger
+[docs]: ./README.md
 [core-contrib]:
   https://github.com/oasisprotocol/oasis-core/blob/master/CONTRIBUTING.md

--- a/common.mk
+++ b/common.mk
@@ -308,7 +308,7 @@ If you would like to use the Ledger signer plugin with Oasis Core, see the
 [Oasis Core Ledger Docs].
 
 [Change Log]: https://github.com/oasisprotocol/oasis-core-ledger/blob/v$(VERSION)/CHANGELOG.md
-[Oasis Core Ledger Docs]: https://docs.oasis.dev/oasis-core-ledger/#usage
+[Oasis Core Ledger Docs]: https://docs.oasis.io/oasis-core-ledger/#usage
 
 endef
 


### PR DESCRIPTION
Replaces docs.oasis.dev references with docs.oasis.io.